### PR TITLE
Moved news and config APIs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,9 @@ jobs:
           FB_APP_ID="${{ secrets.FB_APP_ID }}"
           FB_MEASUREMENT_ID="${{ secrets.FB_MEASUREMENT_ID }}"
           FB_FUNCTIONS="${{ secrets.FB_FUNCTIONS }}"
+          API_NEWS_PATH="${{ vars.API_NEWS_PATH }}"
+          API_CONFIG_PATH="${{ vars.API_CONFIG_PATH }}"
+          API_BASE_URL="${{ vars.API_BASE_URL }}"
           # manifest
           OAUTH2_CLIENT_ID="${{ secrets.OAUTH2_CLIENT_ID }}"
           OAUTH2_SCOPES="${{ vars.OAUTH2_SCOPES }}"

--- a/src/background/service/conditions-evaluator.ts
+++ b/src/background/service/conditions-evaluator.ts
@@ -1,11 +1,12 @@
 import type { NewsConditionType } from '@/shared/types/news-types';
 
+import packageJson from '../../../package.json';
 import { userWalletService } from '../service';
 import { StorageEvaluator } from '../service/storage-evaluator';
 
 import openapi from './openapi';
 
-const CURRENT_VERSION = chrome.runtime.getManifest().version;
+const CURRENT_VERSION = packageJson.version;
 
 class ConditionsEvaluator {
   private async evaluateCondition(condition: NewsConditionType): Promise<boolean> {
@@ -19,7 +20,13 @@ class ConditionsEvaluator {
 
       case 'canUpgrade':
         const latestVersion = await openapi.getLatestVersion();
-        return this.compareVersions(CURRENT_VERSION, latestVersion) < 0;
+        try {
+          const canUpgrade = this.compareVersions(CURRENT_VERSION, latestVersion) < 0;
+          return canUpgrade;
+        } catch (err) {
+          console.error('Error evaluating canUpgrade', err);
+          return false;
+        }
 
       case 'insufficientStorage': {
         const currentAddress = userWalletService.getCurrentAddress();
@@ -53,14 +60,14 @@ class ConditionsEvaluator {
     return 0;
   }
 
-  async evaluateConditions(conditions?: NewsConditionType[]): Promise<boolean> {
+  async evaluateConditions(conditions?: { type: NewsConditionType }[]): Promise<boolean> {
     if (!conditions || conditions.length === 0) {
       return true; // No conditions means always show
     }
 
     // Evaluate all conditions (AND logic)
     for (const condition of conditions) {
-      if (!(await this.evaluateCondition(condition))) {
+      if (!(await this.evaluateCondition(condition.type))) {
         return false;
       }
     }
@@ -76,6 +83,7 @@ class ConditionsEvaluator {
   async evaluateBalanceCondition(address: string): Promise<boolean> {
     const storageEvaluator = new StorageEvaluator();
     const { isBalanceSufficient } = await storageEvaluator.evaluateStorage(address);
+
     return !isBalanceSufficient;
   }
 }

--- a/src/background/service/openapi.ts
+++ b/src/background/service/openapi.ts
@@ -2333,7 +2333,6 @@ class OpenApiService {
 
   getNews = async (): Promise<NewsItem[]> => {
     // Get news from firebase function
-    const baseURL = getFirbaseFunctionUrl();
 
     const cachedNews = await storage.getExpiry('news');
 
@@ -2341,7 +2340,13 @@ class OpenApiService {
       return cachedNews;
     }
 
-    const data = await this.sendRequest('GET', '/news', {}, {}, baseURL);
+    const data = await this.sendRequest(
+      'GET',
+      process.env.API_NEWS_PATH,
+      {},
+      {},
+      process.env.API_BASE_URL
+    );
 
     const timeNow = new Date(Date.now());
 

--- a/src/background/service/openapi.ts
+++ b/src/background/service/openapi.ts
@@ -2454,9 +2454,15 @@ class OpenApiService {
     }
 
     try {
-      const config = this.store.config.get_version;
-      const data = await this.sendRequest(config.method, config.path);
-      const version = data.extensionVersion;
+      const result = await this.sendRequest(
+        'GET',
+        process.env.API_CONFIG_PATH,
+        {},
+        {},
+        process.env.API_BASE_URL
+      );
+
+      const version = result.version;
 
       // Cache for 1 hour
       await storage.setExpiry('latestVersion', version, 3600000);

--- a/src/background/utils/remoteConfig.ts
+++ b/src/background/utils/remoteConfig.ts
@@ -118,12 +118,14 @@ class fetchRemoteConfig {
         );
         // fetch(`${baseURL}/config`);
         // const result = await config.json();
-        this.configState.result = result;
+        const config = result.config;
+
+        this.configState.result = config;
         this.configState.expireTime = exp;
-        await storage.set('freeGas', result.features.free_gas);
-        await storage.set('alchemyAPI', result.features.alchemy_api);
+        await storage.set('freeGas', config.features.free_gas);
+        await storage.set('alchemyAPI', config.features.alchemy_api);
         // console.log('remoteConfig ->', result, result.features.free_gas)
-        return result;
+        return config;
       } catch (err) {
         console.error(err);
         await storage.set('freeGas', defaultConfig.features.free_gas);

--- a/src/background/utils/remoteConfig.ts
+++ b/src/background/utils/remoteConfig.ts
@@ -109,7 +109,13 @@ class fetchRemoteConfig {
     const exp = 1000 * 60 * 60 * 1 + now.getTime();
     if (expire < now.getTime()) {
       try {
-        const result = await openapi.sendRequest('GET', '/config', {}, {}, BASE_FUNCTIONS_URL);
+        const result = await openapi.sendRequest(
+          'GET',
+          process.env.API_CONFIG_PATH,
+          {},
+          {},
+          process.env.API_BASE_URL
+        );
         // fetch(`${baseURL}/config`);
         // const result = await config.json();
         this.configState.result = result;

--- a/src/shared/types/news-types.ts
+++ b/src/shared/types/news-types.ts
@@ -30,5 +30,5 @@ export interface NewsItem {
   url?: string;
   expiryTime: Date;
   displayType: NewsDisplayType;
-  conditions?: NewsConditionType[];
+  conditions?: { type: NewsConditionType }[];
 }

--- a/src/ui/views/Dashboard/Components/news-item.tsx
+++ b/src/ui/views/Dashboard/Components/news-item.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardMedia, IconButton, Typography, Box, Tooltip } fr
 import React, { useEffect, useRef, useState } from 'react';
 
 import { useNews } from '@/ui/utils/NewsContext';
-import { openInternalPageInTab } from '@/ui/utils/webapi';
+import { openInTab } from '@/ui/utils/webapi';
 import type { NewsItem } from 'background/service/networkModel';
 
 export const NewsItemCard = ({ item }: { item: NewsItem }) => {
@@ -149,7 +149,7 @@ export const NewsItemCard = ({ item }: { item: NewsItem }) => {
                   textOverflow: 'ellipsis',
                   cursor: item.url ? 'pointer' : 'default',
                 }}
-                onClick={item.url ? () => item.url && openInternalPageInTab(item.url) : undefined}
+                onClick={item.url ? () => item.url && openInTab(item.url) : undefined}
               >
                 {item.body}
               </Typography>
@@ -167,7 +167,7 @@ export const NewsItemCard = ({ item }: { item: NewsItem }) => {
             >
               <Box
                 component="span"
-                onClick={() => item.url && openInternalPageInTab(item.url)}
+                onClick={() => item.url && openInTab(item.url)}
                 sx={{
                   cursor: 'pointer',
                   display: 'flex',


### PR DESCRIPTION
## Related Issue
Closes #299


## Summary of Changes
Moved API endpoint for news and config to lillico.app so it's off firebase

## Need Regression Testing
- [ ] Yes
- [X] No

## Risk Assessment
The end points are simple functioins that have no permissions. The extension already has permission to access any site. The code to generate the data is identical to firebase.
- [ ] Low
- [X] Medium
- [ ] High

## Additional Notes
<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)
<!-- Attach any screenshots that help explain your changes -->
