### PR TITLE
[FIX] Add missing storage warning messages and enhance error handling

### DIFF
--- a/_raw/_locales/en/messages.json
+++ b/_raw/_locales/en/messages.json
@@ -1316,6 +1316,9 @@
     "message": "Import Profile"
   },
   "Insufficient_Storage": {
+    "message": "Insufficient storage."
+  },
+  "Almost_run_out_of_account_storage": {
     "message": "Almost run out of account storage."
   },
   "Insufficient_storage_after_action": {

--- a/_raw/_locales/ja/messages.json
+++ b/_raw/_locales/ja/messages.json
@@ -1316,6 +1316,9 @@
     "message": "プロファイルをインポート"
   },
   "Insufficient_Storage": {
+    "message": "ストレージが不足しています"
+  },
+  "Almost_run_out_of_account_storage": {
     "message": "アカウントのストレージが不足しています"
   },
   "Transaction_failed_storage_exceeded": {

--- a/_raw/_locales/ru/messages.json
+++ b/_raw/_locales/ru/messages.json
@@ -1316,6 +1316,9 @@
     "message": "Импортировать профиль"
   },
   "Insufficient_Storage": {
+    "message": "Недостаточно памяти"
+  },
+  "Almost_run_out_of_account_storage": {
     "message": "В вашем аккаунте недостаточно места для хранения данных"
   },
   "Transaction_failed_storage_exceeded": {

--- a/_raw/_locales/zh_CN/messages.json
+++ b/_raw/_locales/zh_CN/messages.json
@@ -1316,6 +1316,9 @@
     "message": "导入账户"
   },
   "Insufficient_Storage": {
+    "message": "存储不足"
+  },
+  "Almost_run_out_of_account_storage": {
     "message": "帐户存储空间几乎耗尽"
   },
   "Transaction_failed_storage_exceeded": {

--- a/src/background/service/news.ts
+++ b/src/background/service/news.ts
@@ -40,8 +40,14 @@ class NewsService {
     const filteredNewsPromises = news
       .filter((n) => !this.isDismissed(n.id))
       .map(async (newsItem) => {
-        const shouldShow = await conditionsEvaluator.evaluateConditions(newsItem.conditions);
-        return shouldShow ? newsItem : null;
+        try {
+          const shouldShow = await conditionsEvaluator.evaluateConditions(newsItem.conditions);
+          return shouldShow ? newsItem : null;
+        } catch (error) {
+          // Catch error here otherwise the whole news list will be empty
+          console.error('Error evaluating conditions', error);
+          return null;
+        }
       });
     const filteredNews = await Promise.all(filteredNewsPromises)
       .catch((error) => {

--- a/src/messages.json
+++ b/src/messages.json
@@ -1289,6 +1289,9 @@
     "message": "Import Profile"
   },
   "Insufficient_Storage": {
+    "message": "Insufficient storage."
+  },
+  "Almost_run_out_of_account_storage": {
     "message": "Almost run out of account storage."
   },
   "Transaction_failed_storage_exceeded": {

--- a/src/ui/FRWComponent/WarningStorageLowSnackbar.tsx
+++ b/src/ui/FRWComponent/WarningStorageLowSnackbar.tsx
@@ -13,7 +13,7 @@ export const WarningStorageLowSnackbar = ({
   isLowStorageAfterAction,
 }: WarningStorageLowSnackbarProps = {}) => {
   const message = isLowStorage
-    ? chrome.i18n.getMessage('Insufficient_storage')
+    ? chrome.i18n.getMessage('Almost_run_out_of_account_storage')
     : isLowStorageAfterAction
       ? chrome.i18n.getMessage('Insufficient_storage_after_action')
       : undefined;


### PR DESCRIPTION
## Related Issue
Closes #316

## Summary of Changes
- Added new message entries for "Insufficient Storage" and "Almost run out of account storage" in English, Japanese, Russian, and Chinese locales.
- Updated the `WarningStorageLowSnackbar` component to use the new "Almost run out of account storage" message.
- Enhanced error handling in the `NewsService` class to prevent the news list from being emptied due to evaluation errors.

## Need Regression Testing
News items and storage alert should be tested again.
- [X] Yes
- [ ] No

## Risk Assessment
Nothing dangerous in this
- [X] Low
- [ ] Medium
- [ ] High

