### PR TITLE
Use package version for manifest

### DIFF
--- a/build/prepareManifest.ts
+++ b/build/prepareManifest.ts
@@ -5,6 +5,9 @@ import { fileURLToPath } from 'url';
 
 import dotenv from 'dotenv';
 
+import packageJson from '../package.json';
+const { version } = packageJson;
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -51,6 +54,8 @@ async function prepare() {
     client_id: process.env.OAUTH2_CLIENT_ID,
     scopes: OAUTH2_SCOPES.split(','),
   };
+  // Update the version in the manifest
+  manifest.version = version;
 
   if (mode === 'dev') {
     manifest.key = process.env.MANIFEST_KEY;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-reference-wallet",
-  "version": "2.6.3",
+  "version": "2.6.6",
   "description": "Digital wallet created for everyone.",
   "type": "module",
   "scripts": {


### PR DESCRIPTION


## Related Issue
Closes #327

## Summary of Changes
update package version to 2.6.6 and integrate version into manifest preparation

## Need Regression Testing
- [ ] Yes
- [X] No

## Risk Assessment
- [X] Low
- [ ] Medium
- [ ] High

