### PR TITLE
330-feature-create-environments-for-dev-and-pr-builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,15 +1,12 @@
 name: Production Build
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
   push:
-    branches: [dev, master]
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment: production
+    environment: ${{ github.ref_name == 'master' && 'production' || github.ref_name == 'dev' && 'staging' || 'development' }}
 
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Production Build
+name: Extension Build
 
 on:
   push:
@@ -66,7 +66,7 @@ jobs:
           MIXPANEL_TOKEN="${{ secrets.MIXPANEL_TOKEN }}"
           EOF
 
-      - name: Build production
+      - name: Build
         run: pnpm run build:ci
         env:
           CI: true


### PR DESCRIPTION
## Related Issue
Closes #330


## Summary of Changes
Now uses production environment on GitHub only for pushes to master, staging for pushes to dev, and development for any other branch. This makes it easier to find builds for testing and deployment

## Need Regression Testing
- [ ] Yes
- [X] No

## Risk Assessment
No code changes just workflow file
- [X] Low
- [ ] Medium
- [ ] High

