### PR TITLE
Corrected target network message

### DIFF
--- a/src/ui/views/Approval/components/EthApproval/EthSwitch/index.tsx
+++ b/src/ui/views/Approval/components/EthApproval/EthSwitch/index.tsx
@@ -162,7 +162,7 @@ const EthSwitch = ({ params: { origin, target } }: ConnectProps) => {
                   textAlign: 'center',
                 }}
               >
-                {currentNetwork}
+                {target}
               </Typography>
             </Box>
             <img style={{ width: '116px' }} src={Link} />


### PR DESCRIPTION
## Related Issue
Closes #376

## Summary of Changes
Now uses the correct variable for the target network in the message. Note it was only a text change - no logic has been altered

## Need Regression Testing
- [ ] Yes
- [X] No

## Risk Assessment
- [X] Low
- [ ] Medium
- [ ] High
