### PR TITLE
fix: ensure directory exists before saving auth keys

### DIFF
--- a/e2e/utils/helper.ts
+++ b/e2e/utils/helper.ts
@@ -17,10 +17,13 @@ export const getClipboardText = async () => {
 // save keys auth file
 export const saveAuth = async (auth) => {
   if (auth) {
-    await fs.writeFileSync(keysFilePath, JSON.stringify(auth));
+    // Ensure directory exists
+    const dirPath = path.dirname(keysFilePath);
+    fs.mkdirSync(dirPath, { recursive: true });
+    fs.writeFileSync(keysFilePath, JSON.stringify(auth));
   } else {
     if (fs.existsSync(keysFilePath)) {
-      await fs.unlinkSync(keysFilePath);
+      fs.unlinkSync(keysFilePath);
     }
   }
 };


### PR DESCRIPTION
## Related Issue
Closes #398

## Summary of Changes
Now checks that the playwright/.auth folder exists and creates it if not

## Need Regression Testing
- [ ] Yes
- [X] No

## Risk Assessment
- [X] Low
- [ ] Medium
- [ ] High
