### PR TITLE
Now throws in getEvmAddress

### DIFF
--- a/src/background/controller/wallet.ts
+++ b/src/background/controller/wallet.ts
@@ -1731,8 +1731,12 @@ export class WalletController extends BaseController {
   };
 
   getEvmAddress = async () => {
-    const wallet = await userWalletService.getEvmWallet();
+    const wallet = userWalletService.getEvmWallet();
     const address = withPrefix(wallet.address) || '';
+
+    if (!isValidEthereumAddress(address)) {
+      throw new Error('Invalid Ethereum address');
+    }
     return address;
   };
 
@@ -3368,7 +3372,8 @@ export class WalletController extends BaseController {
   };
 
   getEvmEnabled = async (): Promise<boolean> => {
-    const address = await this.getEvmAddress();
+    // Get straight from the userWalletService as getEvmAddress() throws an error if the address is not valid
+    const address = userWalletService.getEvmWallet();
     return !!address && isValidEthereumAddress(address);
   };
 


### PR DESCRIPTION
## Related Issue
Closes #406

## Summary of Changes
Now throws in getEvmAddress if no valid address

## Need Regression Testing
I'd test all the evm functions to make sure this works correctly. See if you can create an account with no EVM address and do something evm related
- [X] Yes
- [ ] No

## Risk Assessment
- [ ] Low
- [X] Medium
- [ ] High
