### PR TITLE
fix: improve hex value validation in EVM wallet transactions

### DIFF
--- a/src/background/controller/wallet.ts
+++ b/src/background/controller/wallet.ts
@@ -2128,8 +2128,18 @@ export class WalletController extends BaseController {
     const dataArray = Uint8Array.from(dataBuffer);
     const regularArray = Array.from(dataArray);
 
+    // Handle the case where the value is '0.0'
+    if (/^0\.0+$/.test(value)) {
+      value = '0x0';
+    }
+
     if (!value.startsWith('0x')) {
       value = '0x' + value;
+    }
+
+    // At this point the value should be a valid hex string. Check to make sure
+    if (!/^0x[0-9a-fA-F]+$/.test(value)) {
+      throw new Error('Invalid hex string value');
     }
 
     // Convert hex to BigInt
@@ -2165,6 +2175,11 @@ export class WalletController extends BaseController {
     const dataArray = Uint8Array.from(dataBuffer);
     const regularArray = Array.from(dataArray);
 
+    // Handle the case where the value is '0.0'
+    if (/^0\.0+$/.test(value)) {
+      value = '0x0';
+    }
+
     if (!value.startsWith('0x')) {
       value = '0x' + value;
     }
@@ -2182,7 +2197,10 @@ export class WalletController extends BaseController {
         value = web3.utils.toHex(value);
       }
     }
-
+    // At this point the value should be a valid hex string. Check to make sure
+    if (!/^0x[0-9a-fA-F]+$/.test(value)) {
+      throw new Error('Invalid hex string value');
+    }
     // Convert hex to BigInt directly to avoid potential number overflow
     const transactionValue = value === '0x' ? BigInt(0) : BigInt(value);
 


### PR DESCRIPTION
## Related Issue
Closes #408 (was 100 in FRW)

## Summary of Changes
Handles the case where value is 0.0 and double checks that the value is a valid hex string before sending the transaction

## Need Regression Testing
Check EVM transactions and dapSendEvmTX
- [X] Yes
- [ ] No

## Risk Assessment
- [X] Low
- [ ] Medium
- [ ] High

