### PR TITLE
Price formatter

### DIFF
--- a/src/shared/utils/formatPrice.test.ts
+++ b/src/shared/utils/formatPrice.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect } from 'vitest';
+
+import { formatPrice } from './formatPrice';
+
+describe('formatPrice', () => {
+  const DEFAULT_THRESHOLD = 4;
+
+  it('should handle zero', () => {
+    const testCases = [
+      {
+        input: 0,
+        threshold: 4,
+        expected: { leadingPart: '0.00', zeroPart: null, endingPart: null },
+      },
+    ];
+
+    testCases.forEach(({ input, threshold, expected }) => {
+      const result = formatPrice(input, threshold);
+      expect(result).toEqual({
+        price: input,
+        formattedPrice: expected,
+      });
+    });
+  });
+
+  it('should format numbers >= 1 with two decimal places', () => {
+    const testCases = [
+      { input: 1.23456, threshold: 4, expected: '1.23' },
+      { input: 123.456789, threshold: 4, expected: '123.46' },
+      { input: 1000, threshold: 4, expected: '1000.00' },
+    ];
+
+    testCases.forEach(({ input, threshold, expected }) => {
+      const result = formatPrice(input, threshold);
+      expect(result).toEqual({
+        price: input,
+        formattedPrice: {
+          leadingPart: expected,
+          zeroPart: null,
+          endingPart: null,
+        },
+      });
+    });
+  });
+
+  it('should format numbers < 1 with two significant digits after zeros', () => {
+    const testCases = [
+      { input: 0.123456, threshold: 4, expected: '0.12' },
+      { input: 0.0123456, threshold: 4, expected: '0.012' },
+      { input: 0.00123456, threshold: 4, expected: '0.0012' },
+      { input: 0.000123456, threshold: 4, expected: '0.00012' }, // 3 zeros, not condensed
+    ];
+
+    testCases.forEach(({ input, threshold, expected }) => {
+      const result = formatPrice(input, threshold);
+      expect(result).toEqual({
+        price: input,
+        formattedPrice: {
+          leadingPart: expected,
+          zeroPart: null,
+          endingPart: null,
+        },
+      });
+    });
+  });
+
+  it('should condense numbers with many zeros after decimal', () => {
+    const testCases = [
+      {
+        input: 0.0001234, // 4 zeros total, should not condense yet
+        threshold: 4,
+        expected: {
+          leadingPart: '0.00012',
+          zeroPart: null,
+          endingPart: null,
+        },
+      },
+      {
+        input: 0.00001234, // 4 zeros total, should condense with zeroPart 4
+        threshold: 4,
+        expected: {
+          leadingPart: '0.0',
+          zeroPart: 3,
+          endingPart: '12',
+        },
+      },
+    ];
+
+    testCases.forEach(({ input, threshold, expected }) => {
+      const result = formatPrice(input, threshold);
+      expect(result).toEqual({
+        price: input,
+        formattedPrice: expected,
+      });
+    });
+  });
+
+  it('should handle numbers with up to 8 zeros after decimal', () => {
+    const testCases = [
+      {
+        input: 0.00000001234,
+        expected: {
+          leadingPart: '0.0',
+          zeroPart: 6,
+          endingPart: '12',
+        },
+      },
+      {
+        input: 0.000000001234,
+        expected: {
+          leadingPart: '0.0',
+          zeroPart: 7,
+          endingPart: '12',
+        },
+      },
+    ];
+
+    testCases.forEach(({ input, expected }) => {
+      const result = formatPrice(input, DEFAULT_THRESHOLD);
+      expect(result).toEqual({
+        price: input,
+        formattedPrice: expected,
+      });
+    });
+  });
+
+  it('should handle sequential test cases for all zero counts', () => {
+    const testCases = [
+      {
+        input: 0.1234,
+        threshold: 4,
+        expected: { leadingPart: '0.12', zeroPart: null, endingPart: null },
+      },
+      {
+        input: 0.01234,
+        threshold: 4,
+        expected: { leadingPart: '0.012', zeroPart: null, endingPart: null },
+      },
+      {
+        input: 0.001234,
+        threshold: 4,
+        expected: { leadingPart: '0.0012', zeroPart: null, endingPart: null },
+      },
+      {
+        input: 0.0001234,
+        threshold: 4,
+        expected: { leadingPart: '0.00012', zeroPart: null, endingPart: null },
+      },
+      {
+        input: 0.00001234,
+        threshold: 4,
+        expected: { leadingPart: '0.0', zeroPart: 3, endingPart: '12' },
+      },
+      {
+        input: 0.000001234,
+        threshold: 4,
+        expected: { leadingPart: '0.0', zeroPart: 4, endingPart: '12' },
+      },
+      {
+        input: 0.0000001234,
+        threshold: 4,
+        expected: { leadingPart: '0.0', zeroPart: 5, endingPart: '12' },
+      },
+      {
+        input: 0.00000001234,
+        threshold: 4,
+        expected: { leadingPart: '0.0', zeroPart: 6, endingPart: '12' },
+      },
+    ];
+
+    testCases.forEach(({ input, threshold, expected }) => {
+      const result = formatPrice(input, threshold);
+      expect(result.price).toBe(input);
+      expect(result.formattedPrice).toEqual(expected);
+    });
+  });
+
+  it('should respect different threshold values', () => {
+    const testCases = [
+      {
+        input: 0.0001234, // 4 zeros
+        threshold: 3,
+        expected: {
+          leadingPart: '0.0',
+          zeroPart: 2,
+          endingPart: '12',
+        },
+      },
+      {
+        input: 0.0001234, // 4 zeros
+        threshold: 5,
+        expected: {
+          leadingPart: '0.00012',
+          zeroPart: null,
+          endingPart: null,
+        },
+      },
+      {
+        input: 0.001234, // 2 zeros
+        threshold: 2,
+        expected: {
+          leadingPart: '0.0',
+          zeroPart: 1,
+          endingPart: '12',
+        },
+      },
+      {
+        input: 0.000001234, // 5 zeros
+        threshold: 6,
+        expected: {
+          leadingPart: '0.0000012',
+          zeroPart: null,
+          endingPart: null,
+        },
+      },
+    ];
+
+    testCases.forEach(({ input, threshold, expected }) => {
+      const result = formatPrice(input, threshold);
+      expect(result).toEqual({
+        price: input,
+        formattedPrice: expected,
+      });
+    });
+  });
+
+  it('should handle edge cases with different thresholds', () => {
+    const testCases = [
+      {
+        input: 0,
+        threshold: 2,
+        expected: {
+          leadingPart: '0.00',
+          zeroPart: null,
+          endingPart: null,
+        },
+      },
+      {
+        input: 123.456,
+        threshold: 2,
+        expected: {
+          leadingPart: '123.46',
+          zeroPart: null,
+          endingPart: null,
+        },
+      },
+      {
+        input: 0.00000001234,
+        threshold: 10,
+        expected: {
+          leadingPart: '0.000000012',
+          zeroPart: null,
+          endingPart: null,
+        },
+      },
+      {
+        input: 0.00000001234,
+        threshold: 2,
+        expected: {
+          leadingPart: '0.0',
+          zeroPart: 6,
+          endingPart: '12',
+        },
+      },
+    ];
+
+    testCases.forEach(({ input, threshold, expected }) => {
+      const result = formatPrice(input, threshold);
+      expect(result).toEqual({
+        price: input,
+        formattedPrice: expected,
+      });
+    });
+  });
+});

--- a/src/shared/utils/formatPrice.test.ts
+++ b/src/shared/utils/formatPrice.test.ts
@@ -10,7 +10,7 @@ describe('formatPrice', () => {
       {
         input: 0,
         threshold: 4,
-        expected: { leadingPart: '0.00', zeroPart: null, endingPart: null },
+        expected: { leadingPart: '-', zeroPart: null, endingPart: null },
       },
     ];
 
@@ -230,7 +230,7 @@ describe('formatPrice', () => {
         input: 0,
         threshold: 2,
         expected: {
-          leadingPart: '0.00',
+          leadingPart: '-',
           zeroPart: null,
           endingPart: null,
         },

--- a/src/shared/utils/formatPrice.ts
+++ b/src/shared/utils/formatPrice.ts
@@ -14,7 +14,7 @@ export function formatPrice(price: number, zeroCondenseThreshold = 4): Formatted
     return {
       price,
       formattedPrice: {
-        leadingPart: '0.00',
+        leadingPart: '-',
         zeroPart: null,
         endingPart: null,
       },

--- a/src/shared/utils/formatPrice.ts
+++ b/src/shared/utils/formatPrice.ts
@@ -1,0 +1,77 @@
+interface PriceParts {
+  leadingPart: string;
+  zeroPart: number | null;
+  endingPart: string | null;
+}
+
+interface FormattedPrice {
+  price: number;
+  formattedPrice: PriceParts;
+}
+
+export function formatPrice(price: number, zeroCondenseThreshold = 4): FormattedPrice {
+  if (price === 0) {
+    return {
+      price,
+      formattedPrice: {
+        leadingPart: '0.00',
+        zeroPart: null,
+        endingPart: null,
+      },
+    };
+  }
+
+  if (price >= 1) {
+    return {
+      price,
+      formattedPrice: {
+        leadingPart: price.toFixed(2),
+        zeroPart: null,
+        endingPart: null,
+      },
+    };
+  }
+
+  // Convert to non-scientific notation string
+  const priceStr = price.toFixed(20);
+  const [whole, decimal] = priceStr.split('.');
+
+  // Count total zeros after the decimal point
+  let totalZeros = 0;
+  let firstNonZeroIndex = 0;
+
+  for (let i = 0; i < decimal.length; i++) {
+    if (decimal[i] === '0') {
+      totalZeros++;
+    } else {
+      firstNonZeroIndex = i;
+      break;
+    }
+  }
+
+  // If we don't have enough total zeros to meet threshold, format with 2 significant digits
+  if (totalZeros < zeroCondenseThreshold) {
+    const significantPart = decimal.slice(firstNonZeroIndex, firstNonZeroIndex + 2);
+    const formattedNumber = `0.${'0'.repeat(firstNonZeroIndex)}${significantPart}`;
+    return {
+      price,
+      formattedPrice: {
+        leadingPart: formattedNumber,
+        zeroPart: null,
+        endingPart: null,
+      },
+    };
+  }
+
+  // Break up the price into parts for condensed format
+  // zeroPart should be totalZeros - 1 since first zero is in leadingPart
+  const significantDigits = decimal.slice(firstNonZeroIndex, firstNonZeroIndex + 2);
+  return {
+    price,
+    formattedPrice: {
+      leadingPart: '0.0',
+      zeroPart: totalZeros - 1,
+      endingPart: significantDigits,
+    },
+  };
+}

--- a/src/ui/views/TokenDetail/TokenPrice.tsx
+++ b/src/ui/views/TokenDetail/TokenPrice.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { formatPrice } from '@/shared/utils/formatPrice';
+
+interface TokenPriceProps {
+  price: number;
+  className?: string;
+  showPrefix?: boolean;
+}
+
+export const TokenPrice: React.FC<TokenPriceProps> = ({
+  price,
+  className = '',
+  showPrefix = true,
+}) => {
+  const { formattedPrice } = formatPrice(price);
+  const { leadingPart, zeroPart, endingPart } = formattedPrice;
+
+  return (
+    <span className={className}>
+      {showPrefix && '$'}
+      {leadingPart}
+      {zeroPart !== null && <sub style={{ fontSize: '0.7em' }}>{zeroPart}</sub>}
+      {endingPart}
+    </span>
+  );
+};


### PR DESCRIPTION
## Related Issue

Closes #454

Adds formatting price to create a subscript 

## Summary of Changes

Addes helper to format prices,

## Need Regression Testing


- [ ] Yes
- [x] No

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

## Additional Notes

This only a UI component with helper method and tests. It's not been integrated into the existing UI.

## Screenshots (if applicable)
![Screenshot 2025-02-04 at 18 09 07](https://github.com/user-attachments/assets/899a84d2-b71e-4dec-a94d-cffeb1de876b)

![Screenshot 2025-02-04 at 18 09 21](https://github.com/user-attachments/assets/2aa21b4c-a75a-4e92-a54c-1b2e41fa5afb)


