### PR TITLE
Runs test job only on pushes to dev, master or any tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,9 @@ jobs:
     needs: build
     if: github.ref_type == 'tag' || github.ref_name == 'dev' || github.ref_name == 'master'
     runs-on: ubuntu-latest
+    concurrency:
+      group: tests-${{ github.workflow }}
+      cancel-in-progress: false
     environment: >-
       ${{
         github.ref_type == 'tag' && 'production' ||

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,14 +104,13 @@ jobs:
 
   test:
     needs: build
-    timeout-minutes: 60
+    if: github.ref_type == 'tag' || github.ref_name == 'dev' || github.ref_name == 'master'
     runs-on: ubuntu-latest
     environment: >-
       ${{
         github.ref_type == 'tag' && 'production' ||
         github.ref_name == 'master' && 'production' ||
-        github.ref_name == 'dev' && 'staging' ||
-        'development'
+        github.ref_name == 'dev' && 'staging'
       }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Related Issue

Closes #474

## Summary of Changes

Changed the github workflow. Runs test job only on pushes to dev, master or any tag

## Need Regression Testing
No code changes
- [ ] Yes
- [X] No

## Risk Assessment
- [X] Low
- [ ] Medium
- [ ] High
