### PR TITLE
477-feature-ci-tests-should-stop-the-workflow-on-first-fail-after-retry

### DIFF
--- a/e2e/sendTransaction.test.ts
+++ b/e2e/sendTransaction.test.ts
@@ -6,7 +6,13 @@ import {
   switchToEvm,
   waitForTransaction,
 } from './utils/helper';
-export const sendTokenCOA = async ({ page, tokenname, receiver, successtext }) => {
+export const sendTokenCOA = async ({
+  page,
+  tokenname,
+  receiver,
+  successtext,
+  amount = '0.000112134354657',
+}) => {
   // Wait for the EVM account to be loaded
   await getCurrentAddress(page);
   await page.getByRole('tab', { name: 'coins' }).click();
@@ -15,37 +21,42 @@ export const sendTokenCOA = async ({ page, tokenname, receiver, successtext }) =
   await page.getByRole('button', { name: 'SEND' }).click();
   await page.getByPlaceholder('Search address(0x), or flow').click();
   await page.getByPlaceholder('Search address(0x), or flow').fill(receiver);
-  await page.getByPlaceholder('Amount').fill('0.000112134354657');
+  await page.getByPlaceholder('Amount').fill(amount);
   await page.getByRole('button', { name: 'Next' }).click();
   await page.getByRole('button', { name: 'Send' }).click();
   // Wait for the transaction to be completed
-  await waitForTransaction({ page, successtext });
+  await waitForTransaction({ page, successtext, amount });
 };
 
-export const moveTokenCOA = async ({ page, tokenname, successtext }) => {
+export const moveTokenCOA = async ({
+  page,
+  tokenname,
+  successtext,
+  amount = '0.000112134354657',
+}) => {
   // Wait for the EVM account to be loaded
   await getCurrentAddress(page);
   await page.getByRole('tab', { name: 'coins' }).click();
   await page.getByRole('button', { name: tokenname }).click();
   await page.getByRole('button', { name: 'Move' }).click();
   await page.getByPlaceholder('Amount').click();
-  await page.getByPlaceholder('Amount').fill('0.000112134354657');
+  await page.getByPlaceholder('Amount').fill(amount);
   await page.getByRole('button', { name: 'Move' }).click();
   // Wait for the transaction to be completed
-  await waitForTransaction({ page, successtext });
+  await waitForTransaction({ page, successtext, amount });
 };
 
-export const moveTokenCoaHomepage = async ({ page, tokenname }) => {
+export const moveTokenCoaHomepage = async ({ page, tokenname, amount = '0.000000012345' }) => {
   await getCurrentAddress(page);
   await page.getByRole('button', { name: 'Move' }).click();
   await page.getByRole('button', { name: 'Move Tokens' }).click();
   await page.getByRole('combobox').click();
   await page.getByRole('option', { name: tokenname, exact: true }).getByRole('img').click();
   await page.getByPlaceholder('Amount').click();
-  await page.getByPlaceholder('Amount').fill('0.000000012345');
+  await page.getByPlaceholder('Amount').fill(amount);
   await page.getByRole('button', { name: 'Move' }).click();
   // Wait for the transaction to be completed
-  await waitForTransaction({ page, successtext: 'success' });
+  await waitForTransaction({ page, successtext: 'success', amount });
 };
 
 test.beforeEach(async ({ page, extensionId }) => {
@@ -78,7 +89,6 @@ test('send Staked Flow COA to COA', async ({ page }) => {
 //Send FTS from COA to FLOW
 test('send Flow COA to FLOW', async ({ page }) => {
   // This can take a while
-  test.setTimeout(60_000);
   // Send FLOW token from COA to FLOW
   await sendTokenCOA({
     page,
@@ -89,7 +99,6 @@ test('send Flow COA to FLOW', async ({ page }) => {
 });
 
 test('send USDC token COA to FLOW', async ({ page }) => {
-  test.setTimeout(60_000);
   // Send USDC token from COA to FLOW
   await sendTokenCOA({
     page,
@@ -102,7 +111,6 @@ test('send USDC token COA to FLOW', async ({ page }) => {
 //Send FTs from COA to EOA (metamask)
 test('send Flow COA to EOA', async ({ page }) => {
   // This can take a while
-  test.setTimeout(60_000);
   // Send FLOW token from COA to EOA
   await sendTokenCOA({
     page,
@@ -113,7 +121,6 @@ test('send Flow COA to EOA', async ({ page }) => {
 });
 
 test('send BETA token COA to EOA', async ({ page }) => {
-  test.setTimeout(60_000);
   // Send BETA token from COA to EOA
   await sendTokenCOA({
     page,
@@ -124,7 +131,6 @@ test('send BETA token COA to EOA', async ({ page }) => {
 });
 //Move FTs from COA to FLOW
 test('move Flow COA to FLOW', async ({ page }) => {
-  test.setTimeout(60_000);
   // Move FLOW token from COA to FLOW
   await moveTokenCOA({
     page,
@@ -134,7 +140,6 @@ test('move Flow COA to FLOW', async ({ page }) => {
 });
 
 test('move USDC token COA to FLOW', async ({ page }) => {
-  test.setTimeout(60_000);
   // Move USDC token from COA to EOA
   await moveTokenCOA({
     page,
@@ -145,7 +150,6 @@ test('move USDC token COA to FLOW', async ({ page }) => {
 
 //Move from main page
 test('move Flow COA to FLOW homepage', async ({ page }) => {
-  test.setTimeout(60_000);
   // Move FLOW token from FLOW to COA
   await moveTokenCoaHomepage({
     page,
@@ -154,7 +158,6 @@ test('move Flow COA to FLOW homepage', async ({ page }) => {
 });
 
 test('move USDC token COA to FLOW homepage', async ({ page }) => {
-  test.setTimeout(60_000);
   // Move USDC token from FLOW to COA
   await moveTokenCoaHomepage({
     page,

--- a/e2e/sendTransaction.test.ts
+++ b/e2e/sendTransaction.test.ts
@@ -162,6 +162,7 @@ test('move USDC token COA to FLOW homepage', async ({ page }) => {
   await moveTokenCoaHomepage({
     page,
     tokenname: 'Bridged USDC (Celer)',
+    amount: '0.000123',
   });
 });
 //Send NFT from COA to COA

--- a/e2e/sendTransactionFromFlow.test.ts
+++ b/e2e/sendTransactionFromFlow.test.ts
@@ -5,7 +5,12 @@ import {
   getCurrentAddress,
   waitForTransaction,
 } from './utils/helper';
-export const sendTokenFlow = async ({ page, tokenname, receiver }) => {
+export const sendTokenFlow = async ({
+  page,
+  tokenname,
+  receiver,
+  amount = '0.000112134354657',
+}) => {
   // Wait for the EVM account to be loaded
   await getCurrentAddress(page);
   await page.getByRole('tab', { name: 'coins' }).click();
@@ -14,35 +19,35 @@ export const sendTokenFlow = async ({ page, tokenname, receiver }) => {
   await page.getByRole('button', { name: 'SEND' }).click();
   await page.getByPlaceholder('Search address(0x), or flow').click();
   await page.getByPlaceholder('Search address(0x), or flow').fill(receiver);
-  await page.getByPlaceholder('Amount').fill('0.000112134354657');
+  await page.getByPlaceholder('Amount').fill(amount);
   await page.getByRole('button', { name: 'Next' }).click();
   await page.getByRole('button', { name: 'Send' }).click();
   // Wait for the transaction to be completed
-  await waitForTransaction({ page, successtext: 'sealed' });
+  await waitForTransaction({ page, successtext: 'sealed', amount });
 };
 
-export const moveTokenFlow = async ({ page, tokenname }) => {
+export const moveTokenFlow = async ({ page, tokenname, amount = '0.000112134354657' }) => {
   await getCurrentAddress(page);
   await page.getByRole('tab', { name: 'coins' }).click();
   await page.getByRole('button', { name: tokenname }).click();
   await page.getByRole('button', { name: 'Move' }).click();
   await page.getByPlaceholder('Amount').click();
-  await page.getByPlaceholder('Amount').fill('0.000112134354657');
+  await page.getByPlaceholder('Amount').fill(amount);
   // Wait for the transaction to be completed
-  await waitForTransaction({ page, successtext: 'sealed' });
+  await waitForTransaction({ page, successtext: 'sealed', amount });
 };
 
-export const moveTokenFlowHomepage = async ({ page, tokenname }) => {
+export const moveTokenFlowHomepage = async ({ page, tokenname, amount = '0.000000012345' }) => {
   await getCurrentAddress(page);
   await page.getByRole('button', { name: 'Move' }).click();
   await page.getByRole('button', { name: 'Move Tokens' }).click();
   await page.getByRole('combobox').click();
   await page.getByRole('option', { name: tokenname, exact: true }).getByRole('img').click();
   await page.getByPlaceholder('Amount').click();
-  await page.getByPlaceholder('Amount').fill('0.000000012345');
+  await page.getByPlaceholder('Amount').fill(amount);
   await page.getByRole('button', { name: 'Move' }).click();
   // Wait for the transaction to be completed
-  await waitForTransaction({ page, successtext: 'sealed' });
+  await waitForTransaction({ page, successtext: 'sealed', amount });
 };
 
 test.beforeEach(async ({ page, extensionId }) => {
@@ -52,7 +57,6 @@ test.beforeEach(async ({ page, extensionId }) => {
 //Send FLOW token from Flow to Flow
 test('send FLOW flow to flow', async ({ page }) => {
   // This can take a while
-  test.setTimeout(60_000);
   await sendTokenFlow({
     page,
     tokenname: /^FLOW \$/i,
@@ -62,7 +66,6 @@ test('send FLOW flow to flow', async ({ page }) => {
 
 //Send StFlow from Flow to Flow
 test('send stFlow flow to flow', async ({ page }) => {
-  test.setTimeout(60_000);
   await sendTokenFlow({
     page,
     tokenname: 'Liquid Staked Flow $',
@@ -73,7 +76,6 @@ test('send stFlow flow to flow', async ({ page }) => {
 //Send FLOW token from Flow to COA
 test('send FLOW flow to COA', async ({ page }) => {
   // This can take a while
-  test.setTimeout(60_000);
   await sendTokenFlow({
     page,
     tokenname: /^FLOW \$/i,
@@ -82,7 +84,6 @@ test('send FLOW flow to COA', async ({ page }) => {
 });
 //Send USDC from Flow to Flow
 test('send USDC flow to COA', async ({ page }) => {
-  test.setTimeout(60_000);
   await sendTokenFlow({
     page,
     tokenname: 'USDC.e (Flow) $',
@@ -93,7 +94,6 @@ test('send USDC flow to COA', async ({ page }) => {
 //Send FLOW token from Flow to EOA
 test('send FLOW flow to EOA', async ({ page }) => {
   // This can take a while
-  test.setTimeout(60_000);
   await sendTokenFlow({
     page,
     tokenname: /^FLOW \$/i,
@@ -103,7 +103,6 @@ test('send FLOW flow to EOA', async ({ page }) => {
 
 //Send BETA from Flow to EOA
 test('send BETA flow to EOA', async ({ page }) => {
-  test.setTimeout(60_000);
   await sendTokenFlow({
     page,
     tokenname: 'BETA $',
@@ -112,7 +111,6 @@ test('send BETA flow to EOA', async ({ page }) => {
 });
 //Move FTs from  Flow to COA
 test('move Flow Flow to COA', async ({ page }) => {
-  test.setTimeout(60_000);
   // Move FLOW token from FLOW to COA
   await moveTokenFlow({
     page,
@@ -121,7 +119,6 @@ test('move Flow Flow to COA', async ({ page }) => {
 });
 
 test('move USDC token COA to FLOW', async ({ page }) => {
-  test.setTimeout(60_000);
   // Move USDC token from FLOW to COA
   await moveTokenFlow({
     page,
@@ -131,7 +128,6 @@ test('move USDC token COA to FLOW', async ({ page }) => {
 
 //Move from main page
 test('move Flow Flow to COA homepage', async ({ page }) => {
-  test.setTimeout(60_000);
   // Move FLOW token from FLOW to COA
   await moveTokenFlowHomepage({
     page,
@@ -140,7 +136,6 @@ test('move Flow Flow to COA homepage', async ({ page }) => {
 });
 
 test('move USDC token COA to FLOW homepage', async ({ page }) => {
-  test.setTimeout(60_000);
   // Move USDC token from FLOW to COA
   await moveTokenFlowHomepage({
     page,

--- a/e2e/sendTransactionFromFlow.test.ts
+++ b/e2e/sendTransactionFromFlow.test.ts
@@ -138,6 +138,7 @@ test('move USDC token FLOW to COA', async ({ page }) => {
   await moveTokenFlow({
     page,
     tokenname: 'USDC.e (Flow)',
+    ingoreFlowCharge: true,
   });
 });
 

--- a/e2e/sendTransactionFromFlow.test.ts
+++ b/e2e/sendTransactionFromFlow.test.ts
@@ -120,11 +120,11 @@ test('move Flow Flow to COA', async ({ page }) => {
   });
 });
 
-test('move USDC token COA to FLOW', async ({ page }) => {
+test('move USDC token FLOW to COA', async ({ page }) => {
   // Move USDC token from FLOW to COA
   await moveTokenFlow({
     page,
-    tokenname: 'Bridged USDC (Celer) $',
+    tokenname: 'USDC.e (Flow)',
   });
 });
 
@@ -137,7 +137,7 @@ test('move Flow Flow to COA homepage', async ({ page }) => {
   });
 });
 
-test('move USDC token COA to FLOW homepage', async ({ page }) => {
+test('move USDC token Flow to COA homepage', async ({ page }) => {
   // Move USDC token from FLOW to COA
   await moveTokenFlowHomepage({
     page,

--- a/e2e/sendTransactionFromFlow.test.ts
+++ b/e2e/sendTransactionFromFlow.test.ts
@@ -10,6 +10,7 @@ export const sendTokenFlow = async ({
   tokenname,
   receiver,
   amount = '0.000112134354657',
+  ingoreFlowCharge = false,
 }) => {
   // Wait for the EVM account to be loaded
   await getCurrentAddress(page);
@@ -23,10 +24,15 @@ export const sendTokenFlow = async ({
   await page.getByRole('button', { name: 'Next' }).click();
   await page.getByRole('button', { name: 'Send' }).click();
   // Wait for the transaction to be completed
-  await waitForTransaction({ page, successtext: 'sealed', amount });
+  await waitForTransaction({ page, successtext: 'sealed', amount, ingoreFlowCharge });
 };
 
-export const moveTokenFlow = async ({ page, tokenname, amount = '0.000112134354657' }) => {
+export const moveTokenFlow = async ({
+  page,
+  tokenname,
+  amount = '0.000112134354657',
+  ingoreFlowCharge = false,
+}) => {
   await getCurrentAddress(page);
   await page.getByRole('tab', { name: 'coins' }).click();
   await page.getByRole('button', { name: tokenname }).click();
@@ -36,10 +42,15 @@ export const moveTokenFlow = async ({ page, tokenname, amount = '0.0001121343546
   await page.getByRole('button', { name: 'Move' }).click();
 
   // Wait for the transaction to be completed
-  await waitForTransaction({ page, successtext: 'sealed', amount });
+  await waitForTransaction({ page, successtext: 'sealed', amount, ingoreFlowCharge });
 };
 
-export const moveTokenFlowHomepage = async ({ page, tokenname, amount = '0.000000012345' }) => {
+export const moveTokenFlowHomepage = async ({
+  page,
+  tokenname,
+  amount = '0.000000012345',
+  ingoreFlowCharge = false,
+}) => {
   await getCurrentAddress(page);
   await page.getByRole('button', { name: 'Move' }).click();
   await page.getByRole('button', { name: 'Move Tokens' }).click();
@@ -49,7 +60,7 @@ export const moveTokenFlowHomepage = async ({ page, tokenname, amount = '0.00000
   await page.getByPlaceholder('Amount').fill(amount);
   await page.getByRole('button', { name: 'Move' }).click();
   // Wait for the transaction to be completed
-  await waitForTransaction({ page, successtext: 'sealed', amount });
+  await waitForTransaction({ page, successtext: 'sealed', amount, ingoreFlowCharge });
 };
 
 test.beforeEach(async ({ page, extensionId }) => {
@@ -90,6 +101,7 @@ test('send USDC flow to COA', async ({ page }) => {
     page,
     tokenname: 'USDC.e (Flow) $',
     receiver: process.env.TEST_RECEIVER_EVM_ADDR!,
+    ingoreFlowCharge: true,
   });
 });
 
@@ -109,6 +121,7 @@ test('send BETA flow to EOA', async ({ page }) => {
     page,
     tokenname: 'BETA $',
     receiver: process.env.TEST_RECEIVER_METAMASK_EVM_ADDR!,
+    ingoreFlowCharge: true,
   });
 });
 //Move FTs from  Flow to COA
@@ -142,5 +155,6 @@ test('move USDC token Flow to COA homepage', async ({ page }) => {
   await moveTokenFlowHomepage({
     page,
     tokenname: 'USDC.e (Flow)',
+    ingoreFlowCharge: true,
   });
 });

--- a/e2e/sendTransactionFromFlow.test.ts
+++ b/e2e/sendTransactionFromFlow.test.ts
@@ -155,6 +155,7 @@ test('move USDC token Flow to COA homepage', async ({ page }) => {
   await moveTokenFlowHomepage({
     page,
     tokenname: 'USDC.e (Flow)',
+    amount: '0.0000123',
     ingoreFlowCharge: true,
   });
 });

--- a/e2e/sendTransactionFromFlow.test.ts
+++ b/e2e/sendTransactionFromFlow.test.ts
@@ -33,6 +33,8 @@ export const moveTokenFlow = async ({ page, tokenname, amount = '0.0001121343546
   await page.getByRole('button', { name: 'Move' }).click();
   await page.getByPlaceholder('Amount').click();
   await page.getByPlaceholder('Amount').fill(amount);
+  await page.getByRole('button', { name: 'Move' }).click();
+
   // Wait for the transaction to be completed
   await waitForTransaction({ page, successtext: 'sealed', amount });
 };

--- a/e2e/utils/helper.ts
+++ b/e2e/utils/helper.ts
@@ -435,7 +435,12 @@ export const switchToFlow = async ({ page, extensionId }) => {
   await getCurrentAddress(page);
 };
 
-export const waitForTransaction = async ({ page, successtext = 'success', amount = '' }) => {
+export const waitForTransaction = async ({
+  page,
+  successtext = 'success',
+  amount = '',
+  ingoreFlowCharge = false,
+}) => {
   // Wait for the transaction to be completed
   await page.waitForURL(/.*dashboard\?activity=1.*/);
   const url = await page.url();
@@ -447,7 +452,9 @@ export const waitForTransaction = async ({ page, successtext = 'success', amount
   const progressBar = page.getByRole('progressbar');
   await expect(progressBar).toBeVisible();
   // Get the pending item with the cadence txId that was put in the url and status is pending
-  const pendingItem = page.getByTestId(new RegExp(`^.*${txId}.*$`)).filter({ hasText: 'Pending' });
+  const pendingItem = page
+    .getByTestId(new RegExp(`^.*${txId}.*${ingoreFlowCharge ? '(?<!FlowToken)' : ''}$`))
+    .filter({ hasText: 'Pending' });
 
   await expect(pendingItem).toBeVisible({
     timeout: 60_000,
@@ -456,7 +463,7 @@ export const waitForTransaction = async ({ page, successtext = 'success', amount
 
   // Get the executed item with the cadence txId that was put in the url and status is success
   const executedItem = page
-    .getByTestId(new RegExp(`^.*${txId}.*$`))
+    .getByTestId(new RegExp(`^.*${txId}.*${ingoreFlowCharge ? '(?<!FlowToken)' : ''}$`))
     .filter({ hasText: successtext });
 
   await expect(executedItem).toBeVisible({

--- a/e2e/utils/helper.ts
+++ b/e2e/utils/helper.ts
@@ -463,9 +463,9 @@ export const waitForTransaction = async ({ page, successtext = 'success', amount
     timeout: 60_000,
   });
 
-  if (amount) {
-    await expect(executedItem).toContainText(amount);
-  }
+  // if (amount) {
+  //   await expect(executedItem).toContainText(amount);
+  // }
 };
 
 export const expect = test.expect;

--- a/e2e/utils/helper.ts
+++ b/e2e/utils/helper.ts
@@ -435,7 +435,7 @@ export const switchToFlow = async ({ page, extensionId }) => {
   await getCurrentAddress(page);
 };
 
-export const waitForTransaction = async ({ page, successtext = 'success' }) => {
+export const waitForTransaction = async ({ page, successtext = 'success', amount = '' }) => {
   // Wait for the transaction to be completed
   await page.waitForURL(/.*dashboard\?activity=1.*/);
   const url = await page.url();
@@ -462,6 +462,10 @@ export const waitForTransaction = async ({ page, successtext = 'success' }) => {
   await expect(executedItem).toBeVisible({
     timeout: 60_000,
   });
+
+  if (amount) {
+    await expect(executedItem).toContainText(amount);
+  }
 };
 
 export const expect = test.expect;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,6 +26,8 @@ export default defineConfig({
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI ? 'github' : 'html',
+  /* Stop after the first test failure */
+  maxFailures: process.env.CI ? 1 : 0,
 
   // set the timeout for each test to 120 seconds. We're sending transactions and waiting for them to be confirmed.
   timeout: 120_000,

--- a/src/background/service/transaction.ts
+++ b/src/background/service/transaction.ts
@@ -261,18 +261,30 @@ class Transaction {
         transactionHolder.type = tx.type;
         transactionHolder.transferType = tx.transfer_type;
         // see if there's a pending item for this transaction
-        const pendingItem = this.session.pendingItem[network].find((item) => item.hash === tx.txid);
+        const pendingItem = this.session.pendingItem[network].find(
+          (item) =>
+            item.hash.includes(tx.txid) ||
+            item.cadenceTxId?.includes(tx.txid) ||
+            item.evmTxIds?.includes(tx.txid)
+        );
         if (pendingItem) {
           // Store the cadence transaction id
           transactionHolder.cadenceTxId = pendingItem.cadenceTxId;
+          transactionHolder.evmTxIds = pendingItem.evmTxIds;
+          transactionHolder.hash = pendingItem.hash;
         } else {
           // see if there's an existing transaction with cadenceId in the store
           const existingTx = this.store.transactionItem[network]?.find(
-            (item) => item.hash === tx.txid
+            (item) =>
+              item.hash.includes(tx.txid) ||
+              item.cadenceTxId?.includes(tx.txid) ||
+              item.evmTxIds?.includes(tx.txid)
           );
           if (existingTx && existingTx.cadenceTxId) {
             // Found existing cadence transaction id
             transactionHolder.cadenceTxId = existingTx.cadenceTxId;
+            transactionHolder.evmTxIds = existingTx.evmTxIds;
+            transactionHolder.hash = existingTx.hash;
           }
         }
 

--- a/src/background/service/transaction.ts
+++ b/src/background/service/transaction.ts
@@ -1,4 +1,5 @@
 import type { TransactionStatus } from '@onflow/typedefs';
+import { ConcatenationScope } from 'webpack';
 
 import { isValidEthereumAddress } from '@/shared/utils/address';
 import createPersistStore from 'background/utils/persisitStore';
@@ -168,6 +169,7 @@ class Transaction {
 
     const evmTxIds: string[] = transactionStatus.events?.reduce(
       (transactionIds: string[], event) => {
+        console.log('event', event);
         if (event.type.includes('EVM') && !!event.data?.hash) {
           const hashBytes = event.data.hash.map((byte) => parseInt(byte));
           const hash = '0x' + Buffer.from(hashBytes).toString('hex');
@@ -180,7 +182,7 @@ class Transaction {
       },
       [] as string[]
     );
-
+    console.log('evmTxIds', evmTxIds);
     txItem.evmTxIds = [...evmTxIds];
 
     if (evmTxIds.length > 0) {
@@ -191,7 +193,7 @@ class Transaction {
       }
       txItem.hash = `${txItem.cadenceTxId || txItem.hash}_${evmTxIds.join('_')}`;
     }
-
+    console.log('txItem', txItem);
     txList[txItemIndex] = txItem;
 
     this.session.pendingItem[network] = [...txList];

--- a/src/ui/views/Wallet/TransferList.tsx
+++ b/src/ui/views/Wallet/TransferList.tsx
@@ -182,7 +182,7 @@ const TransferList = () => {
               {(transactions || []).map((tx) => {
                 return (
                   <ListItem
-                    key={`${tx.cadenceTxId || tx.hash}_${tx.interaction}`}
+                    key={`${tx.hash}_${tx.interaction}`}
                     data-testid={`${tx.cadenceTxId || tx.hash}_${tx.interaction}`}
                     secondaryAction={
                       <EndListItemText

--- a/src/ui/views/Wallet/TransferList.tsx
+++ b/src/ui/views/Wallet/TransferList.tsx
@@ -183,7 +183,7 @@ const TransferList = () => {
                 return (
                   <ListItem
                     key={`${tx.hash}_${tx.interaction}`}
-                    data-testid={`${tx.cadenceTxId || tx.hash}_${tx.interaction}`}
+                    data-testid={`${tx.hash}_${tx.interaction}`}
                     secondaryAction={
                       <EndListItemText
                         status={tx.status}


### PR DESCRIPTION
## Related Issue

Closes #477
<!-- If this PR addresses an issue, link it here  -->

## Summary of Changes

Updated workflow to stop tests, then corrected a couple of things that were breaking the tests. Updated the transaction activity to copy across EVM and cadence ids, and corrected a couple of tests that were missing a click and / or address. Updated the CI with new EOA addresss variable

## Need Regression Testing

All e2e tests should pass

- [ ] Yes
- [X] No

## Risk Assessment

- [X] Low
- [ ] Medium
- [ ] High
