### PR TITLE
481-bug-link-to-flowscan-broken

### DIFF
--- a/src/background/service/transaction.ts
+++ b/src/background/service/transaction.ts
@@ -1,7 +1,5 @@
 import type { TransactionStatus } from '@onflow/typedefs';
-import { ConcatenationScope } from 'webpack';
 
-import { isValidEthereumAddress } from '@/shared/utils/address';
 import createPersistStore from 'background/utils/persisitStore';
 import createSessionStore from 'background/utils/sessionStore';
 
@@ -157,9 +155,10 @@ class Transaction {
   updatePending = (txId: string, network: string, transactionStatus: TransactionStatus): string => {
     const txList = this.session.pendingItem[network];
     const txItemIndex = txList.findIndex((item) => item.hash.includes(txId));
+    let combinedTxHash = txId;
     if (txItemIndex === -1) {
       // txItem not found, return
-      return txId;
+      return combinedTxHash;
     }
     const txItem = txList[txItemIndex];
 
@@ -169,7 +168,6 @@ class Transaction {
 
     const evmTxIds: string[] = transactionStatus.events?.reduce(
       (transactionIds: string[], event) => {
-        console.log('event', event);
         if (event.type.includes('EVM') && !!event.data?.hash) {
           const hashBytes = event.data.hash.map((byte) => parseInt(byte));
           const hash = '0x' + Buffer.from(hashBytes).toString('hex');
@@ -182,7 +180,6 @@ class Transaction {
       },
       [] as string[]
     );
-    console.log('evmTxIds', evmTxIds);
     txItem.evmTxIds = [...evmTxIds];
 
     if (evmTxIds.length > 0) {
@@ -191,9 +188,8 @@ class Transaction {
         // TODO: Check there aren't 100s of evmTxIds
         console.warn('updatePending - evmTxIds.length > 10', evmTxIds);
       }
-      txItem.hash = `${txItem.cadenceTxId || txItem.hash}_${evmTxIds.join('_')}`;
+      combinedTxHash = `${txItem.cadenceTxId || txItem.hash}_${evmTxIds.join('_')}`;
     }
-    console.log('txItem', txItem);
     txList[txItemIndex] = txItem;
 
     this.session.pendingItem[network] = [...txList];
@@ -201,7 +197,7 @@ class Transaction {
     chrome.runtime.sendMessage({ msg: 'transferListUpdated' });
 
     // Return the hash of the transaction
-    return txItem.hash;
+    return combinedTxHash;
   };
 
   removePending = (txId: string, address: string, network: string) => {

--- a/src/background/service/transaction.ts
+++ b/src/background/service/transaction.ts
@@ -205,7 +205,11 @@ class Transaction {
     const newList = txList.filter((item) => {
       // Supports hashes with multiple ids
       // e.g. cadenceTxId_evmTxId
-      return !item.hash.includes(txId);
+      return (
+        !item.hash.includes(txId) &&
+        !item.cadenceTxId?.includes(txId) &&
+        !item.evmTxIds?.includes(txId)
+      );
     });
     this.session.pendingItem[network] = [...newList];
   };

--- a/src/ui/views/Wallet/TransferList.tsx
+++ b/src/ui/views/Wallet/TransferList.tsx
@@ -201,10 +201,14 @@ const TransferList = () => {
                       dense={true}
                       onClick={() => {
                         {
+                          // Link to the first evm tx if there are multiple. Once the indexer updates, it'll show all the evm transactions
+                          // This is a temporary solution until the indexer updates
+                          const txHash =
+                            (tx.evmTxIds && tx.evmTxIds.length) === 1 ? tx.evmTxIds[0] : tx.hash;
                           const url =
                             monitor === 'flowscan'
-                              ? `${flowscanURL}/tx/${tx.hash}`
-                              : `${viewSourceURL}/${tx.hash}`;
+                              ? `${flowscanURL}/tx/${txHash}`
+                              : `${viewSourceURL}/${txHash}`;
                           window.open(url);
                         }
                       }}

--- a/src/ui/views/Wallet/TransferList.tsx
+++ b/src/ui/views/Wallet/TransferList.tsx
@@ -35,7 +35,6 @@ const TransferList = () => {
     fetchTransactions();
     const handler = (req) => {
       if (req.msg === 'transferListUpdated') {
-        console.log('Transfer list updated');
         fetchTransactions();
       }
       return true;
@@ -180,10 +179,11 @@ const TransferList = () => {
             <>
               {' '}
               {(transactions || []).map((tx) => {
+                const txCombinedKey = `${tx.cadenceTxId || tx.hash}${tx.evmTxIds ? `_${tx.evmTxIds.join('_')}` : ''}_${tx.interaction}`;
                 return (
                   <ListItem
-                    key={`${tx.hash}_${tx.interaction}`}
-                    data-testid={`${tx.hash}_${tx.interaction}`}
+                    key={txCombinedKey}
+                    data-testid={txCombinedKey}
                     secondaryAction={
                       <EndListItemText
                         status={tx.status}


### PR DESCRIPTION
## Related Issue

Closes #481


## Summary of Changes

No longer changes hash in transactions. Instead checks evm id and cadence id lists for matching transactions. Frontend tests now use that if they exist to build the ids

## Need Regression Testing
Check flowscan for all transaction types
- [X] Yes
- [ ] No

## Risk Assessment

- [X] Low
- [ ] Medium
- [ ] High
