### PR TITLE
Now allows 18 decimal places for EVM - EVM flow transfers. Restricts transfers to Cadence to 8 decimal places

### DIFF
--- a/src/background/service/openapi.ts
+++ b/src/background/service/openapi.ts
@@ -295,7 +295,8 @@ const defaultFlowToken = {
   },
   logoURI:
     'https://cdn.jsdelivr.net/gh/FlowFans/flow-token-list@main/token-registry/A.1654653399040a61.FlowToken/logo.svg',
-  decimals: 8,
+  // On Evm networks we can use up to 18 decimals
+  decimals: 18,
   symbol: 'flow',
 };
 

--- a/src/ui/reducers/transaction-reducer.ts
+++ b/src/ui/reducers/transaction-reducer.ts
@@ -222,8 +222,15 @@ export const transactionReducer = (
         // Calculate the remaining balance after the transaction
         remainingBalance = balance.minus(new BN(amountInCoin));
       } else if (state.fiatOrCoin === 'coin') {
+        // Should limit non-evm networks to 8 decimals
+        const maxNetworkDecimals =
+          state.fromNetwork === 'Evm' && state.toNetwork === 'Evm' ? 18 : 8;
         // Check if the amount entered has too many decimal places
-        amountInCoin = trimDecimalAmount(action.payload, state.selectedToken.decimals, 'entering');
+        amountInCoin = trimDecimalAmount(
+          action.payload,
+          Math.min(maxNetworkDecimals, state.selectedToken.decimals),
+          'entering'
+        );
 
         // Check if the balance is exceeded
         const amountBN = new BN(


### PR DESCRIPTION
## Related Issue

Closes #534


## Summary of Changes

Now allows 18 decimal places for EVM - EVM flow transfers. Restricts transfers to Cadence to 8 decimal places

## Need Regression Testing

Affects flow transfers and transfers between EVM and Cadence

- [X] Yes
- [ ] No

## Risk Assessment

- [ ] Low
- [X] Medium
- [ ] High
