### PR TITLE
Prevent linking to flowscan for unindexed transactions

### DIFF
--- a/src/background/controller/wallet.ts
+++ b/src/background/controller/wallet.ts
@@ -27,7 +27,7 @@ import {
 import eventBus from '@/eventBus';
 import { type FeatureFlagKey, type FeatureFlags } from '@/shared/types/feature-types';
 import { type TrackingEvents } from '@/shared/types/tracking-types';
-import { type TransactionState } from '@/shared/types/transaction-types';
+import { type TransferItem, type TransactionState } from '@/shared/types/transaction-types';
 import { type LoggedInAccount } from '@/shared/types/wallet-types';
 import { ensureEvmAddressPrefix, isValidEthereumAddress, withPrefix } from '@/shared/utils/address';
 import { getSignAlgo } from '@/shared/utils/algo';
@@ -3000,7 +3000,10 @@ export class WalletController extends BaseController {
     offset: number,
     _expiry = 60000,
     forceRefresh = false
-  ) => {
+  ): Promise<{
+    count: number;
+    list: TransferItem[];
+  }> => {
     const network = await this.getNetwork();
     const now = new Date();
     const expiry = transactionService.getExpiry();
@@ -3014,6 +3017,7 @@ export class WalletController extends BaseController {
     const pending = await transactionService.listPending(network);
 
     return {
+      // NOTE: count is the total number of INDEXED transactions
       count: await transactionService.getCount(),
       list: pending?.length ? [...pending, ...sealed] : sealed,
     };

--- a/src/background/service/transaction.ts
+++ b/src/background/service/transaction.ts
@@ -1,5 +1,6 @@
 import type { TransactionStatus } from '@onflow/typedefs';
 
+import { type TransferItem } from '@/shared/types/transaction-types';
 import createPersistStore from 'background/utils/persisitStore';
 import createSessionStore from 'background/utils/sessionStore';
 
@@ -8,30 +9,6 @@ interface TransactionStore {
   total: number;
   transactionItem: Record<string, TransferItem[]>;
   pendingItem: Record<string, TransferItem[]>;
-}
-
-interface TransferItem {
-  coin: string;
-  status: string;
-  sender: string;
-  receiver: string;
-  hash: string;
-  time: number;
-  interaction: string;
-  amount: string;
-  error: boolean;
-  token: string;
-  title: string;
-  additionalMessage: string;
-  type: number;
-  transferType: number;
-  image: string;
-  // If true, the transaction is indexed
-  indexed: boolean;
-  // The cadence transaction id
-  cadenceTxId?: string;
-  // The EVM transaction ids
-  evmTxIds?: string[];
 }
 
 const now = new Date();
@@ -273,7 +250,6 @@ class Transaction {
           // Store the cadence transaction id
           transactionHolder.cadenceTxId = pendingItem.cadenceTxId;
           transactionHolder.evmTxIds = pendingItem.evmTxIds;
-          transactionHolder.hash = pendingItem.hash;
         } else {
           // see if there's an existing transaction with cadenceId in the store
           const existingTx = this.store.transactionItem[network]?.find(
@@ -286,7 +262,6 @@ class Transaction {
             // Found existing cadence transaction id
             transactionHolder.cadenceTxId = existingTx.cadenceTxId;
             transactionHolder.evmTxIds = existingTx.evmTxIds;
-            transactionHolder.hash = existingTx.hash;
           }
         }
 

--- a/src/background/webapi/notification.ts
+++ b/src/background/webapi/notification.ts
@@ -14,10 +14,18 @@ const create = (
   priority = 0
 ) => {
   const randomId = +new Date();
-  chrome.notifications.create(url && `${url}_randomId_=${randomId}`, {
+
+  const notificationId = url && `${url}?randomId_=${randomId}`;
+  // Often the registry has a PNG equivalent to the SVG
+  // This can't be that reliable, but it's the best we can do for now
+  // Notifications don't support SVGs
+  // From what I can tell, Flow is the only token that has an SVG logo
+  const iconUrl = icon.replace(/\.svg$/, '.png');
+
+  chrome.notifications.create(notificationId, {
     type: 'basic',
     title,
-    iconUrl: icon,
+    iconUrl,
     message,
     priority,
   });

--- a/src/shared/types/transaction-types.ts
+++ b/src/shared/types/transaction-types.ts
@@ -57,3 +57,28 @@ export type TransactionState = {
   // The transaction if of the transaction
   txId?: string;
 };
+
+// The activity item type
+export interface TransferItem {
+  coin: string;
+  status: string;
+  sender: string;
+  receiver: string;
+  hash: string;
+  time: number;
+  interaction: string;
+  amount: string;
+  error: boolean;
+  token: string;
+  title: string;
+  additionalMessage: string;
+  type: number;
+  transferType: number;
+  image: string;
+  // If true, the transaction is indexed
+  indexed: boolean;
+  // The cadence transaction id
+  cadenceTxId?: string;
+  // The EVM transaction ids
+  evmTxIds?: string[];
+}

--- a/src/ui/hooks/useTransferListHook.ts
+++ b/src/ui/hooks/useTransferListHook.ts
@@ -44,11 +44,11 @@ export const useTransferList = () => {
         );
 
         setLoading(false);
-        if (data['count'] > 0) {
-          setCount(data['count'].toString());
-          setShowButton(data['count'] > 15);
+        if (data.count > 0) {
+          setCount(data.count.toString());
+          setShowButton(data.count > 15);
         }
-        setTransactions(data['list']);
+        setTransactions(data.list);
       } catch {
         setLoading(false);
       }

--- a/src/ui/stores/transferListStore.ts
+++ b/src/ui/stores/transferListStore.ts
@@ -1,7 +1,8 @@
 import { create } from 'zustand';
 
+import { type TransferItem } from '@/shared/types/transaction-types';
 interface TransferListState {
-  transactions: any[];
+  transactions: TransferItem[];
   monitor: string;
   flowscanURL: string;
   viewSourceURL: string;

--- a/src/ui/views/SendTo/TransferConfirmation.tsx
+++ b/src/ui/views/SendTo/TransferConfirmation.tsx
@@ -114,7 +114,7 @@ const TransferConfirmation = ({
         txId,
         true,
         `${transactionState.amount} ${transactionState.coinInfo.coin} Sent`,
-        `You have sent ${transactionState.amount} ${transactionState.selectedToken?.symbol} to ${transactionState.toContact?.contact_name}. \nClick to view this transaction.`,
+        `You have sent ${transactionState.amount} ${transactionState.selectedToken?.symbol} to ${transactionState.toAddress}. \nClick to view this transaction.`,
         transactionState.coinInfo.icon
       );
       // Record the recent contact

--- a/src/ui/views/Wallet/TransferList.tsx
+++ b/src/ui/views/Wallet/TransferList.tsx
@@ -216,7 +216,6 @@ const TransferList = () => {
                       onClick={() => {
                         // Link to the first evm tx if there are multiple. Once the indexer updates, it'll show all the evm transactions
                         // This is a temporary solution until the indexer updates
-                        console.log('tx', tx);
                         if (!tx.indexed) {
                           return;
                         }

--- a/src/ui/views/Wallet/TransferList.tsx
+++ b/src/ui/views/Wallet/TransferList.tsx
@@ -23,7 +23,6 @@ import { useTransferList } from '@/ui/hooks/useTransferListHook';
 import activity from 'ui/FRWAssets/svg/activity.svg';
 
 import { TokenBalance } from '../TokenDetail/TokenBalance';
-import { TokenValue } from '../TokenDetail/TokenValue';
 
 dayjs.extend(relativeTime);
 
@@ -215,17 +214,18 @@ const TransferList = () => {
                       sx={{ paddingRight: '0px' }}
                       dense={true}
                       onClick={() => {
-                        {
-                          // Link to the first evm tx if there are multiple. Once the indexer updates, it'll show all the evm transactions
-                          // This is a temporary solution until the indexer updates
-                          const txHash =
-                            (tx.evmTxIds && tx.evmTxIds.length) === 1 ? tx.evmTxIds[0] : tx.hash;
-                          const url =
-                            monitor === 'flowscan'
-                              ? `${flowscanURL}/tx/${txHash}`
-                              : `${viewSourceURL}/${txHash}`;
-                          window.open(url);
+                        // Link to the first evm tx if there are multiple. Once the indexer updates, it'll show all the evm transactions
+                        // This is a temporary solution until the indexer updates
+                        console.log('tx', tx);
+                        if (!tx.indexed) {
+                          return;
                         }
+                        const txHash = tx.hash;
+                        const url =
+                          monitor === 'flowscan'
+                            ? `${flowscanURL}/tx/${txHash}`
+                            : `${viewSourceURL}/${txHash}`;
+                        window.open(url);
                       }}
                     >
                       <ListItemIcon
@@ -235,10 +235,14 @@ const TransferList = () => {
                         fontSize="medium"
                         sx={{ color: '#fff', cursor: 'pointer', border: '1px solid', borderRadius: '35px' }}
                       /> */}
-                        <CardMedia
-                          sx={{ width: '30px', height: '30px', borderRadius: '15px' }}
-                          image={tx.image}
-                        />
+                        {tx.image ? (
+                          <CardMedia
+                            sx={{ width: '30px', height: '30px', borderRadius: '15px' }}
+                            image={tx.image}
+                          />
+                        ) : (
+                          <Skeleton variant="circular" width={30} height={30} />
+                        )}
                       </ListItemIcon>
                       <StartListItemText
                         time={tx.time}


### PR DESCRIPTION
## Related Issue

Closes #540


## Summary of Changes

Shared TransferItem type, stopped re-hashing indexed transactions as it broke links. Updated click handler to prevent trying to navigate to flowscan for un-indexed activities

## Need Regression Testing

Send transaction tests should cover it
- [ ] Yes
- [X] No

## Risk Assessment

- [X] Low
- [ ] Medium
- [ ] High
