### PR TITLE
Updated validateAmount and trimDecimalAmount to require a decimal point in fix64 strings

### DIFF
--- a/src/shared/utils/__tests__/number.test.ts
+++ b/src/shared/utils/__tests__/number.test.ts
@@ -63,16 +63,16 @@ describe('trimDecimalAmount', () => {
 
 describe('trimDecimalAmount clean', () => {
   it('should handle empty and invalid inputs', () => {
-    expect(trimDecimalAmount('', 2, 'clean')).toBe('0');
-    expect(trimDecimalAmount('   ', 2, 'clean')).toBe('0');
-    expect(trimDecimalAmount('.', 2, 'clean')).toBe('0');
-    expect(trimDecimalAmount('..', 2, 'clean')).toBe('0');
+    expect(trimDecimalAmount('', 2, 'clean')).toBe('0.0');
+    expect(trimDecimalAmount('   ', 2, 'clean')).toBe('0.0');
+    expect(trimDecimalAmount('.', 2, 'clean')).toBe('0.0');
+    expect(trimDecimalAmount('..', 2, 'clean')).toBe('0.0');
   });
 
   it('should format final amounts correctly', () => {
     // Basic cases
-    expect(trimDecimalAmount('123', 2, 'clean')).toBe('123');
-    expect(trimDecimalAmount('123.', 2, 'clean')).toBe('123');
+    expect(trimDecimalAmount('123', 2, 'clean')).toBe('123.0');
+    expect(trimDecimalAmount('123.', 2, 'clean')).toBe('123.0');
     expect(trimDecimalAmount('123.4', 2, 'clean')).toBe('123.4');
     expect(trimDecimalAmount('123.40', 2, 'clean')).toBe('123.4');
     // Removes extra zeros even when truncating
@@ -82,29 +82,29 @@ describe('trimDecimalAmount clean', () => {
     expect(trimDecimalAmount('123.479', 2, 'clean')).toBe('123.47');
 
     // Multiple decimal points
-    expect(trimDecimalAmount('12..34.56', 2, 'clean')).toBe('12');
+    expect(trimDecimalAmount('12..34.56', 2, 'clean')).toBe('12.0');
     expect(trimDecimalAmount('12.34.56', 2, 'clean')).toBe('12.34');
 
     // Leading zeros
-    expect(trimDecimalAmount('000123', 2, 'clean')).toBe('123');
-    expect(trimDecimalAmount('0', 2, 'clean')).toBe('0');
+    expect(trimDecimalAmount('000123', 2, 'clean')).toBe('123.0');
+    expect(trimDecimalAmount('0', 2, 'clean')).toBe('0.0');
     expect(trimDecimalAmount('00.123', 2, 'clean')).toBe('0.12');
 
     // Decimal cases
     expect(trimDecimalAmount('.123', 2, 'clean')).toBe('0.12');
-    expect(trimDecimalAmount('.', 2, 'clean')).toBe('0');
-    expect(trimDecimalAmount('', 2, 'clean')).toBe('0');
+    expect(trimDecimalAmount('.', 2, 'clean')).toBe('0.0');
+    expect(trimDecimalAmount('', 2, 'clean')).toBe('0.0');
     // Handle getting rid of trailing zeros
-    expect(trimDecimalAmount('123.000', 2, 'clean')).toBe('123');
+    expect(trimDecimalAmount('123.000', 2, 'clean')).toBe('123.0');
   });
 });
 
 describe('validateAmount', () => {
   describe('with exact=false (default)', () => {
     it('should validate whole numbers', () => {
-      expect(validateAmount('123', 2)).toBe(true);
-      expect(validateAmount('0', 2)).toBe(true);
-      expect(validateAmount('1000000', 2)).toBe(true);
+      expect(validateAmount('123.0', 2)).toBe(true);
+      expect(validateAmount('0.0', 2)).toBe(true);
+      expect(validateAmount('1000000.0', 2)).toBe(true);
     });
 
     it('should validate numbers with decimals up to maxDecimals', () => {
@@ -126,6 +126,8 @@ describe('validateAmount', () => {
       expect(validateAmount('12.34.56', 2)).toBe(false);
       expect(validateAmount('-123.45', 2)).toBe(false);
       expect(validateAmount('+123.45', 2)).toBe(false);
+      expect(validateAmount('123', 2)).toBe(false);
+      expect(validateAmount('0', 2)).toBe(false);
     });
   });
 
@@ -137,6 +139,7 @@ describe('validateAmount', () => {
 
     it('should reject numbers with fewer decimals than maxDecimals', () => {
       expect(validateAmount('123.4', 2, true)).toBe(false);
+      expect(validateAmount('123.0', 2, true)).toBe(false);
       expect(validateAmount('123', 2, true)).toBe(false);
     });
 
@@ -187,9 +190,9 @@ describe('convertToIntegerAmount', () => {
   });
 
   it('should handle whole numbers', () => {
-    expect(convertToIntegerAmount('123', 2)).toBe('12300');
-    expect(convertToIntegerAmount('1000', 4)).toBe('10000000');
-    expect(convertToIntegerAmount('0', 6)).toBe('0');
+    expect(convertToIntegerAmount('123.0', 2)).toBe('12300');
+    expect(convertToIntegerAmount('1000.0', 4)).toBe('10000000');
+    expect(convertToIntegerAmount('0.0', 6)).toBe('0');
   });
 
   it('should handle amounts with exact decimal places', () => {
@@ -202,12 +205,13 @@ describe('convertToIntegerAmount', () => {
     expect(() => convertToIntegerAmount('abc', 2)).toThrow('Invalid amount or decimal places');
     expect(() => convertToIntegerAmount('123..45', 2)).toThrow('Invalid amount or decimal places');
     expect(() => convertToIntegerAmount('-123.45', 2)).toThrow('Invalid amount or decimal places');
+    expect(() => convertToIntegerAmount('123', 2)).toThrow('Invalid amount or decimal places');
   });
 
   it('should handle zero amounts with different decimal places', () => {
     expect(convertToIntegerAmount('0.0', 4)).toBe('0');
     expect(convertToIntegerAmount('0.00', 4)).toBe('0');
-    expect(convertToIntegerAmount('0', 8)).toBe('0');
+    expect(convertToIntegerAmount('0.0', 8)).toBe('0');
   });
 
   it('should handle amounts with trailing zeros', () => {

--- a/src/shared/utils/number.ts
+++ b/src/shared/utils/number.ts
@@ -76,20 +76,24 @@ export const trimDecimalAmount = (
 
   // Are we displaying or passing the value to a function. i.e. clean up trailing zeros
   if (mode === 'clean') {
-    // If the value is an empty string, return '0'
+    // If the value is an empty string, return '0.0'
     if (trimmedValue === '') {
-      return '0';
+      return '0.0';
     }
     // The user is not in the process of entering the amount, clean the amount to remove trailing zeros
     if (trimmedValue.includes('.')) {
       const [integerPart, decimalPart] = trimmedValue.split('.');
       if (!decimalPart) {
-        return integerPart;
+        return `${integerPart}.0`;
       }
 
       const trimmedDecimal = decimalPart.replace(/0+$/, '');
-      trimmedValue = trimmedDecimal ? `${integerPart}.${trimmedDecimal}` : integerPart;
+      trimmedValue = trimmedDecimal ? `${integerPart}.${trimmedDecimal}` : `${integerPart}.0`;
+    } else {
+      // No decimal point, add one
+      trimmedValue = `${trimmedValue}.0`;
     }
+
     return trimmedValue;
   }
 
@@ -118,6 +122,7 @@ export const trimDecimalAmount = (
 };
 
 // Validate that a string is a valid transaction amount with the given max decimal places
+// Unless maxDecimals is zero, a decimal point is required
 // If exact is true, the amount must have exactly maxDecimals decimal places
 export const validateAmount = (amount: string, maxDecimals: number, exact = false): boolean => {
   const regex =
@@ -125,7 +130,8 @@ export const validateAmount = (amount: string, maxDecimals: number, exact = fals
       ? `^(0|[1-9]\\d*)$`
       : exact
         ? `^(0|[1-9]\\d*)\\.\\d{${maxDecimals}}$`
-        : `^(0|[1-9]\\d*)(\\.\\d{1,${maxDecimals}})?$`;
+        : `^(0|[1-9]\\d*)\\.\\d{1,${maxDecimals}}$`;
+
   return new RegExp(regex).test(amount);
 };
 

--- a/src/ui/reducers/transaction-reducer.ts
+++ b/src/ui/reducers/transaction-reducer.ts
@@ -99,6 +99,9 @@ type TransactionAction =
     }
   | {
       type: 'setAmountToMax';
+    }
+  | {
+      type: 'finalizeAmount';
     };
 
 export const getTransactionStateString = (state: TransactionState): TransactionStateString | '' => {
@@ -191,6 +194,13 @@ export const transactionReducer = (
       return {
         ...stateInCoinWithMaxAmount,
         fiatOrCoin: 'fiat',
+      };
+    }
+    case 'finalizeAmount': {
+      return {
+        ...state,
+        amount: trimDecimalAmount(state.amount, state.selectedToken.decimals, 'clean'),
+        fiatAmount: trimDecimalAmount(state.fiatAmount, 8, 'clean'),
       };
     }
     case 'setAmount': {

--- a/src/ui/views/SendTo/SendToCadenceOrEvm.tsx
+++ b/src/ui/views/SendTo/SendToCadenceOrEvm.tsx
@@ -25,12 +25,14 @@ const SendToCadenceOrEvm = ({
   handleTokenChange,
   handleSwitchFiatOrCoin,
   handleMaxClick,
+  handleFinalizeAmount,
 }: {
   transactionState: TransactionState;
   handleAmountChange: (amountString: string) => void;
   handleTokenChange: (tokenAddress: string) => void;
   handleSwitchFiatOrCoin: () => void;
   handleMaxClick: () => void;
+  handleFinalizeAmount: () => void;
 }) => {
   const history = useHistory();
   const wallet = useWallet();
@@ -188,6 +190,8 @@ const SendToCadenceOrEvm = ({
 
             <Button
               onClick={() => {
+                // Finalize the transfer amount
+                handleFinalizeAmount();
                 setConfirmationOpen(true);
               }}
               variant="contained"

--- a/src/ui/views/SendTo/index.tsx
+++ b/src/ui/views/SendTo/index.tsx
@@ -114,6 +114,12 @@ export const SendTo = () => {
     });
   };
 
+  const handleFinalizeAmount = () => {
+    dispatch({
+      type: 'finalizeAmount',
+    });
+  };
+
   return (
     <SendToCadenceOrEvm
       transactionState={transactionState}
@@ -121,6 +127,7 @@ export const SendTo = () => {
       handleTokenChange={handleTokenChange}
       handleSwitchFiatOrCoin={handleSwitchFiatOrCoin}
       handleMaxClick={handleMaxClick}
+      handleFinalizeAmount={handleFinalizeAmount}
     />
   );
 };


### PR DESCRIPTION
## Related Issue

Closes #549

## Summary of Changes

Updated validateAmount and trimDecimalAmount to require a decimal point in fix64 strings

## Need Regression Testing

- [ ] Yes
- [X] No

## Risk Assessment

- [X] Low
- [ ] Medium
- [ ] High

## Additional Notes

<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)

<!-- Attach any screenshots that help explain your changes -->
