### PR TITLE
Inject content scripts at `document_start`

### DIFF
--- a/_raw/manifest/manifest.pro.json
+++ b/_raw/manifest/manifest.pro.json
@@ -33,7 +33,8 @@
   "content_scripts": [
     {
       "js": ["content-script.js", "script.js"],
-      "matches": ["file://*/*", "http://*/*", "https://*/*"]
+      "matches": ["file://*/*", "http://*/*", "https://*/*"],
+      "run_at": "document_start"
     }
   ],
   "content_security_policy": {


### PR DESCRIPTION
## Related Issue

Closes #568 

<!-- If this PR addresses an issue, link it here  -->

## Summary of Changes

Inject the content scripts at `document_start` instead of the [default of `document_idle`](https://developer.chrome.com/docs/extensions/develop/concepts/content-scripts#static-declarative).

## Need Regression Testing

<!-- Indicate whether this PR requires regression testing and why. -->

- [ ] Yes
- [X] No* _- This should be a low risk change, however, the maintainers should be more familiar whether there are delibrate reasons for the current content script timing.  I have not personally seen issues during my regression testing with both Cadence & EVM injected wallets_

## Risk Assessment

- [X] Low
- [ ] Medium
- [ ] High

## Additional Notes

N/A

## Screenshots (if applicable)

N/A
