### PR TITLE
Add send NFT from child

### DIFF
--- a/src/ui/views/NFT/SendNFT/SendNFTConfirmation.tsx
+++ b/src/ui/views/NFT/SendNFT/SendNFTConfirmation.tsx
@@ -111,8 +111,12 @@ const SendNFTConfirmation = (props: SendNFTConfirmationProps) => {
     const { address } = props.data.contact;
     const isEvm = activeChild === 'evm';
     const isEvmAddress = address.length > 20;
-    if (!isEvm && isEvmAddress && !isChild) {
-      await flowToEvm();
+    if (!isEvm && isEvmAddress) {
+      if (isChild) {
+        await sendChildNftToEvm();
+      } else {
+        await flowToEvm();
+      }
     } else if (isChild || props.data.linked) {
       sendChildNft();
     } else {
@@ -198,6 +202,39 @@ const SendNFTConfirmation = (props: SendNFTConfirmationProps) => {
     } finally {
       setSending(false);
     }
+  };
+
+  const sendChildNftToEvm = async () => {
+    const contractList = await wallet.openapi.getAllNft();
+    const filteredCollections = contractList.filter(
+      (collection) => collection.name === props.data.nft.collectionName
+    );
+    const flowIdentifier = props.data.contract.flowIdentifier || props.data.nft.flowIdentifier;
+    setSending(true);
+    wallet
+      .batchBridgeChildNFTToEvm(
+        props.data.contact.address,
+        flowIdentifier,
+        [props.data.nft.id],
+        filteredCollections[0]
+      )
+      .then(async (txId) => {
+        wallet.listenTransaction(
+          txId,
+          true,
+          `Move complete`,
+          `You have moved 1 ${props.data.nft.collectionContractName} to your evm address. \nClick to view this transaction.`
+        );
+        props.handleCloseIconClicked();
+        await wallet.setDashIndex(0);
+        setSending(false);
+        history.push(`/dashboard?activity=1&txId=${txId}`);
+      })
+      .catch((err) => {
+        console.error('send flow NFT to evm encounter error: ', err);
+        setSending(false);
+        setFailed(true);
+      });
   };
 
   const flowToEvm = async () => {


### PR DESCRIPTION
I still need to do quite a bit of testing here, but i feel like the send flow from a child account into an EVM address was just completely missing before.

While following that flow, i ended up in the regular sendChildNft flow, which expected a Cadence address.

## Related Issue

Closes #???

## Summary of Changes

Adds `sendChildNftToEvm` function, mostly mimic-ing the same idea from the move flow.

## Need Regression Testing

technically net new functionality

- [ ] Yes
- [x] No

## Risk Assessment

- [ ] Low
- [x] Medium
- [ ] High

## Additional Notes

<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)

<!-- Attach any screenshots that help explain your changes -->
