### PR TITLE
Now shows reset dialog in settings

### DIFF
--- a/src/ui/views/Forgot/Recover/ShowKey.tsx
+++ b/src/ui/views/Forgot/Recover/ShowKey.tsx
@@ -21,7 +21,9 @@ const ShowKey = ({ handleSwitchTab, mnemonic }) => {
   };
 
   const resetWalletClicked = async () => {
-    usewallet.resetPwd();
+    usewallet.resetPwd().then(() => {
+      window.close();
+    });
     // console.log('reset reset reset')
   };
 

--- a/src/ui/views/Forgot/Reset/ResetPage.tsx
+++ b/src/ui/views/Forgot/Reset/ResetPage.tsx
@@ -36,8 +36,9 @@ const ResetPage = (props: AddOrEditAddressProps) => {
   };
 
   const resetWalletClicked = async () => {
-    usewallet.resetPwd();
-    // console.log('reset reset reset')
+    usewallet.resetPwd().then(() => {
+      window.close();
+    });
   };
 
   return (


### PR DESCRIPTION
## Related Issue

Closes #491

## Summary of Changes

Now uses main resetdialog in the settings to indicate all wallets will be reset

## Need Regression Testing

- [ ] Yes
- [X] No

## Risk Assessment


- [X] Low
- [ ] Medium
- [ ] High

## Additional Notes

## Screenshots (if applicable)

<!-- Attach any screenshots that help explain your changes -->
