### PR TITLE
Corrected handling of addressbook fetch errors. Now sets tab to accounts for both EVM and Cadence when sending NFTS

### DIFF
--- a/src/ui/views/NFT/SendNFT/SendToAddress.tsx
+++ b/src/ui/views/NFT/SendNFT/SendToAddress.tsx
@@ -154,35 +154,40 @@ const SendToAddress = () => {
   const state = location.state as NFTDetailState;
 
   const fetchAddressBook = useCallback(async () => {
+    let recent: Contact[] = [];
+    let sortedContacts: Contact[] = [];
     try {
       const response = await usewallet.getAddressBook();
-      let recent = await usewallet.getRecent();
+      recent = await usewallet.getRecent();
       if (recent) {
         recent.forEach((c) => {
-          response.forEach((s) => {
-            if (c.address === s.address && c.contact_name === s.contact_name) {
-              c.contact_type = ContactType.AddressBook;
-            }
-          });
+          if (response) {
+            response.forEach((s) => {
+              if (c.address === s.address && c.contact_name === s.contact_name) {
+                c.contact_type = ContactType.AddressBook;
+              }
+            });
+          }
         });
       } else {
         recent = [];
       }
 
+      if (response) {
+        sortedContacts = response.sort((a, b) =>
+          a.contact_name.toLowerCase().localeCompare(b.contact_name.toLowerCase())
+        );
+      }
+    } catch (err) {
+      console.error('err: ', err);
+    } finally {
       if (recent.length < 1) {
         setTabValue(2);
       }
-
-      const sortedContacts = response.sort((a, b) =>
-        a.contact_name.toLowerCase().localeCompare(b.contact_name.toLowerCase())
-      );
-
       setRecentContacts(recent);
       setSortedContacts(sortedContacts);
       setFilteredContacts(sortedContacts);
       setIsLoading(false);
-    } catch (err) {
-      console.error('err: ', err);
     }
   }, [usewallet]);
 

--- a/src/ui/views/NftEvm/SendNFT/SendToAddress.tsx
+++ b/src/ui/views/NftEvm/SendNFT/SendToAddress.tsx
@@ -159,10 +159,11 @@ const SendToAddress = () => {
   const [media, setMedia] = useState<MatchMedia | null>(null);
 
   const fetchAddressBook = useCallback(async () => {
-    await usewallet.setDashIndex(0);
+    let recent: Contact[] = [];
+    let sortedContacts: Contact[] = [];
     try {
       const response = await usewallet.getAddressBook();
-      let recent = await usewallet.getRecent();
+      recent = await usewallet.getRecent();
       if (recent) {
         recent.forEach((c) => {
           if (response) {
@@ -177,22 +178,21 @@ const SendToAddress = () => {
         recent = [];
       }
 
-      if (recent.length < 1) {
-        setTabValue(1);
-      }
-      let sortedContacts: Contact[] = [];
       if (response) {
         sortedContacts = response.sort((a, b) =>
           a.contact_name.toLowerCase().localeCompare(b.contact_name.toLowerCase())
         );
       }
-
+    } catch (err) {
+      console.error('err: ', err);
+    } finally {
+      if (recent.length < 1) {
+        setTabValue(2);
+      }
       setRecentContacts(recent);
       setSortedContacts(sortedContacts);
       setFilteredContacts(sortedContacts);
       setIsLoading(false);
-    } catch (err) {
-      console.log('err: ', err);
     }
   }, [usewallet]);
 


### PR DESCRIPTION
## Related Issue

Closes #499

## Summary of Changes

Corrected handling of addressbook fetch errors. Now sets tab to accounts for both EVM and Cadence when sending NFTS

## Need Regression Testing

Try clicking send on EVM & Flow  NFTs
- [X] Yes
- [ ] No

## Risk Assessment


- [X] Low
- [ ] Medium
- [ ] High
