### PR TITLE
Saves a timestamp to session storage every 2 seconds to keep the background service worker alive

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -448,3 +448,14 @@ const setEnvironmentBadge = () => {
 
 // Call it when extension starts
 setEnvironmentBadge();
+
+function saveTimestamp() {
+  const timestamp = new Date().toISOString();
+
+  chrome.storage.session.set({ timestamp });
+}
+
+const SAVE_TIMESTAMP_INTERVAL_MS = 2 * 1000;
+
+saveTimestamp();
+setInterval(saveTimestamp, SAVE_TIMESTAMP_INTERVAL_MS);


### PR DESCRIPTION
## Related Issue

Closes #620

## Summary of Changes
Keep the background service worker alive by saving a timestamp every 30 seconds

## Need Regression Testing

- [X] Yes
- [ ] No

## Risk Assessment

Will keep users logged in for longer. This may leave their wallet accessible when they walk away from their desk

- [ ] Low
- [X] Medium
- [ ] High

## Additional Notes

<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)

<!-- Attach any screenshots that help explain your changes -->
