### PR TITLE
dApp connect to locked wallet

### DIFF
--- a/src/background/controller/provider/controller.ts
+++ b/src/background/controller/provider/controller.ts
@@ -149,10 +149,6 @@ const SignTypedDataVersion = {
   V4: 'V4',
 } as const;
 
-function normalize(input: string): string {
-  return input.toLowerCase();
-}
-
 const TypedDataUtils = {
   eip712Hash(message: any, version: string): Buffer {
     const types = { ...message.types };
@@ -210,7 +206,7 @@ class ProviderController extends BaseController {
   };
 
   ethRequestAccounts = async ({ session: { origin, name, icon } }) => {
-    if (!permissionService.hasPermission(origin)) {
+    if (!permissionService.hasPermission(origin) || !Wallet.isUnlocked()) {
       const { defaultChain, signPermission } = await notificationService.requestApproval(
         {
           params: { origin, name, icon },
@@ -222,15 +218,16 @@ class ProviderController extends BaseController {
     }
 
     const currentWallet = await Wallet.getMainWallet();
-
-    let res: string | null;
+    let evmAddress: string = '';
     try {
       // Attempt to query the EVM address
-      res = await Wallet.queryEvmAddress(currentWallet);
-      console.log('Query successful:', res);
+      evmAddress = await Wallet.queryEvmAddress(currentWallet);
+      if (!isValidEthereumAddress(evmAddress)) {
+        throw new Error('Invalid EVM address');
+      }
     } catch (error) {
       // If an error occurs, request approval
-      console.error('Error querying EVM address:', error);
+      console.error('ethRequestAccounts - Error querying EVM address:', error);
 
       await notificationService.requestApproval(
         {
@@ -240,14 +237,13 @@ class ProviderController extends BaseController {
         { height: 599 }
       );
 
-      res = await Wallet.queryEvmAddress(currentWallet);
+      evmAddress = await Wallet.queryEvmAddress(currentWallet);
     }
 
-    res = ensureEvmAddressPrefix(res);
-    const account = res ? [res.toLowerCase()] : [];
+    const account = evmAddress ? [ensureEvmAddressPrefix(evmAddress)] : [];
+
     sessionService.broadcastEvent('accountsChanged', account);
     const connectSite = permissionService.getConnectedSite(origin);
-
     return account;
   };
   ethEstimateGas = async ({ data }) => {
@@ -316,11 +312,11 @@ class ProviderController extends BaseController {
       return;
     }
 
-    let res: string | null;
+    let evmAccount: string | null;
     try {
       // Attempt to query the EVM address
-      res = await Wallet.queryEvmAddress(currentWallet);
-      console.log('Query successful:', res);
+      evmAccount = await Wallet.queryEvmAddress(currentWallet);
+      console.log('Query successful:', evmAccount);
     } catch (error) {
       // If an error occurs, request approval
       console.error('Error querying EVM address:', error);
@@ -333,10 +329,10 @@ class ProviderController extends BaseController {
         { height: 599 }
       );
 
-      res = await Wallet.queryEvmAddress(currentWallet);
+      evmAccount = await Wallet.queryEvmAddress(currentWallet);
     }
 
-    const account = res ? [res.toLowerCase()] : [];
+    const account = evmAccount ? [evmAccount] : [];
     await sessionService.broadcastEvent('accountsChanged', account);
     await permissionService.getConnectedSite(origin);
     const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -439,10 +435,6 @@ class ProviderController extends BaseController {
     return result;
   };
 
-  private _checkAddress = async (address) => {
-    return normalize(address).toLowerCase();
-  };
-
   ethChainId = async ({ session }) => {
     const network = await Wallet.getNetwork();
     if (network === 'testnet') {
@@ -521,7 +513,7 @@ class ProviderController extends BaseController {
       currentChain = 747;
     }
 
-    const paramAddress = request.data.params?.[0].toLowerCase() || '';
+    const paramAddress = request.data.params?.[0] || '';
 
     if (isValidEthereumAddress(paramAddress)) {
       data = request.data.params[1];
@@ -531,14 +523,14 @@ class ProviderController extends BaseController {
       address = request.data.params[1];
     }
 
+    // Potentially shouldn't change the case to compare - we should be checking ERC-55 conformity
     if (
       ensureEvmAddressPrefix(evmaddress!.toLowerCase()) !==
       ensureEvmAddressPrefix(address.toLowerCase())
     ) {
-      console.log('evmaddress address ', evmaddress!.toLowerCase(), address.toLowerCase());
+      console.log('evmaddress address ', evmaddress!, address);
       throw new Error('Provided address does not match the current address');
     }
-    console.log('data address ', address, data);
     const message = typeof data === 'string' ? JSON.parse(data) : data;
 
     const signTypeMethod =
@@ -559,7 +551,6 @@ class ProviderController extends BaseController {
   };
 
   signTypeDataV1 = async (request) => {
-    console.log('eth_signTypedData_v1  ', request);
     let address;
     let data;
     let currentChain;
@@ -594,6 +585,7 @@ class ProviderController extends BaseController {
 
     console.log('evmaddress address ', address, evmaddress);
 
+    // Potentially shouldn't change the case to compare - we should be checking ERC-55 conformity
     if (
       ensureEvmAddressPrefix(evmaddress!.toLowerCase()) !==
       ensureEvmAddressPrefix(address.toLowerCase())

--- a/src/background/controller/provider/rpcFlow.ts
+++ b/src/background/controller/provider/rpcFlow.ts
@@ -25,17 +25,22 @@ const lockedOrigins = new Set<string>();
 const flow = new PromiseFlow();
 const flowContext = flow
   .use(async (ctx, next) => {
+    console.log('ctx #1 - check method', ctx);
     // check method
     const {
       data: { method },
     } = ctx.request;
     ctx.mapMethod = underline2Camelcase(method);
+    console.log('ctx.mapMethod', ctx.mapMethod);
+
     if (!providerController[ctx.mapMethod]) {
       // TODO: make rpc whitelist
       try {
         const result = await providerController.ethRpc(ctx.request.data);
+        console.log('ethRpc result', result);
         return result;
       } catch (error) {
+        console.log('ethRpc error', error);
         // Catch any error and throw the custom error
         throw ethErrors.rpc.methodNotFound({
           message: `method [${ctx.request.data.method}] doesn't have a corresponding handler`,
@@ -46,30 +51,41 @@ const flowContext = flow
 
     return next();
   })
-  .use(async (ctx, next) => {
-    const {
-      request: {
-        session: { origin },
-      },
-      mapMethod,
-    } = ctx;
-    if (!Reflect.getMetadata('SAFE', providerController, mapMethod)) {
-      const mainwallet = await Wallet.getMainWallet();
-      const evmAddress = await Wallet.queryEvmAddress(mainwallet);
-      const currentNetwork = await Wallet.getNetwork();
-      if (!isValidEthereumAddress(evmAddress)) {
-        throw new Error('evm must has at least one account.');
-      }
-      const isUnlock = keyringService.memStore.getState().isUnlocked;
-      const site = permissionService.getConnectedSite(origin);
-      if (mapMethod === 'ethAccounts' && (!site || !isUnlock)) {
-        throw new Error('Origin not connected. Please connect first.');
-      }
-    }
+  // .use(async (ctx, next) => {
+  //   console.log('ctx #2 - check something...', ctx);
 
-    return next();
-  })
+  //   const {
+  //     request: {
+  //       session: { origin },
+  //     },
+  //     mapMethod,
+  //   } = ctx;
+  //   if (!Reflect.getMetadata('SAFE', providerController, mapMethod)) {
+  //     Check that we're unlocked and have a connected site
+  //     const mainwallet = await Wallet.getMainWallet();
+  //     console.log('mainwallet', mainwallet);
+  //     const evmAddress = await Wallet.queryEvmAddress(mainwallet);
+  //     console.log('evmAddress', evmAddress);
+  //     console.log('isValidEthereumAddress', isValidEthereumAddress(evmAddress));
+  //     const currentNetwork = await Wallet.getNetwork();
+
+  //     if (!isValidEthereumAddress(evmAddress)) {
+  //       throw new Error('evm must has at least one account.');
+  //     }
+  //     const isUnlock = keyringService.memStore.getState().isUnlocked;
+  //     const site = permissionService.getConnectedSite(origin);
+  //     console.log('site / isUnlock', site, isUnlock);
+  //     if (mapMethod === 'ethAccounts' && (!site || !isUnlock)) {
+  //       console.log('error', 'Origin not connected. Please connect first');
+
+  //       throw new Error('Origin not connected. Please connect first.');
+  //     }
+  //   }
+
+  //   return next();
+  // })
   .use(async (ctx, next) => {
+    console.log('ctx #3 - check connect', ctx);
     const {
       request: {
         session: { origin, name, icon },
@@ -78,6 +94,10 @@ const flowContext = flow
     } = ctx;
     // check connect
     if (!Reflect.getMetadata('SAFE', providerController, mapMethod)) {
+      console.log(
+        'permissionService.hasPermission(origin)',
+        permissionService.hasPermission(origin)
+      );
       if (!permissionService.hasPermission(origin)) {
         ctx.request.requestedApproval = true;
         const { defaultChain, signPermission } = await notificationService.requestApproval(
@@ -87,6 +107,8 @@ const flowContext = flow
           },
           { height: 599 }
         );
+        console.log('defaultChain / signPermission', defaultChain, signPermission);
+
         permissionService.addConnectedSite(origin, name, icon, defaultChain);
       }
     }
@@ -94,6 +116,8 @@ const flowContext = flow
     return next();
   })
   .use(async (ctx, next) => {
+    console.log('ctx #4 - check need approval', ctx);
+
     // check need approval
     const {
       request: {
@@ -128,6 +152,7 @@ const flowContext = flow
     return next();
   })
   .use(async (ctx) => {
+    console.log('ctx #5 - process request', ctx);
     const { approvalRes, mapMethod, request } = ctx;
     // process request
     const [approvalType] = Reflect.getMetadata('APPROVAL', providerController, mapMethod) || [];

--- a/src/background/service/password.ts
+++ b/src/background/service/password.ts
@@ -1,3 +1,5 @@
+// @todo: Remove this entire service.
+// See the comments for why this entire service is pointless, and if it DID work why it's dangerous.
 import { createSessionStore } from 'background/utils';
 
 import googleDriveService from './googleDrive';
@@ -10,9 +12,17 @@ interface PasswordStore {
 
 class Password {
   store!: PasswordStore;
-  // rand  = (Math.random() + 1).toString(36).substring(7);
 
   init = async () => {
+    // This initializes the store
+    // createSessionStore calls createProxy, which creates a proxy object that watches for changes to the store
+    // The idea is when a change is detected, it calls debounce, which queues a function to save the store to sessionStorage
+    // So INITIALLY, the store is of type PasswordStore
+    //
+    // However, we are using SESSION storage to store the store and the only time this store is created is when init is called.
+    // This happens once when the extension is installed - which is the start of the session.
+    // So the store is always empty when we create it so it never reads any data from session storage.
+
     this.store = await createSessionStore<PasswordStore>({
       name: 'password',
       template: {
@@ -24,6 +34,24 @@ class Password {
   };
 
   clear = () => {
+    // This is called whenever the wallet is locked, but...
+    //
+    // There is a function in wallet, isUnlocked, that checks if the wallet is locked.
+    // If it is locked, it will TRY to unlock the wallet using the password stored in this service.
+    // Even though the intention of this service was to store the password in session storage,
+    // it will always start out empty because the store is initialized when the extension is installed.
+    // That's where the fun starts...
+    //
+    // If getPassword returns an empty string in isUnlocked, then this function is called.
+    // It looks like the intention of this function is to clear the password from the store.
+    // However, it doesn't do that.
+    // It just sets the store to an empty object
+    // This changes the type of the store to a plain object instead of a session store proxy.
+    //
+    // So after this function is called - which it always will be - any calls to setPassword will not be watched by the proxy.
+    // And the password will not be saved to session storage.
+    //
+    // This is great because we NEVER should have been saving the password to local session storage in the first place.
     this.store = {
       password: '',
       veryfiPwd: '',
@@ -32,15 +60,36 @@ class Password {
   };
 
   getPassword = async (): Promise<any> => {
+    // As stated above, this function is called only from isUnlocked in wallet.
+    //
+    // The intention of this function is to return the password from the store.
+    // However, the store is always empty because it is initialized when the extension is installed.
+    //
+    // Also the only time this function is called is when the wallet is locked.
+    // Locking the wallet clears the store.
+    //
+    // So this function will always return an empty string.
+    //
+    // This is great because we NEVER should have been saving the password to local session storage in the first place.
+
     const encryptedPass = this.store.password;
     const password = await googleDriveService.decrypt(encryptedPass, this.store.rand);
     return password;
   };
 
   setPassword = async (password: string) => {
+    // This function is called when the user sets a password.
+    //
+    // It encrypts the password and saves it to the store object.
+
+    // By the time this function is called, the store is already a plain object in memory as we would have called clear.
+    // So setting this just stores the password in memory - encrypted by this random number which IS NOT the same number as in session storage.
+    //
     const encryptedPass = await googleDriveService.encrypt(password, this.store.rand);
     this.store.password = encryptedPass;
   };
 }
+
+// That's why this entire service is pointless and we should get rid of it
 
 export default new Password();

--- a/src/background/service/permission.ts
+++ b/src/background/service/permission.ts
@@ -32,6 +32,10 @@ class PermissionService {
     });
     this.store = storage || this.store;
 
+    // @todo add a size limit to the LRU cache
+    // We're creating a new LRU cache here with no size limit.
+    // That's the whole point of the LRU cache.
+
     this.lruCache = new LRU();
     const cache: ReadonlyArray<LRU.Entry<string, ConnectedSite>> = (this.store.dumpCache || []).map(
       (item) => ({

--- a/src/background/utils/persisitStore.ts
+++ b/src/background/utils/persisitStore.ts
@@ -3,7 +3,10 @@ import debounce from 'debounce';
 import { storage } from 'background/webapi';
 
 const persistStorage = (name: string, obj: object) => {
-  debounce(() => storage.set(name, obj), 1000);
+  //  if (name === 'userWallets') {
+  console.log('persistStorage', name, JSON.parse(JSON.stringify(obj)));
+  //x}
+  storage.set(name, obj);
 };
 
 interface CreatePersistStoreParams<T> {
@@ -18,11 +21,13 @@ const createPersistStore = async <T extends object>({
   fromStorage = true,
 }: CreatePersistStoreParams<T>): Promise<T> => {
   let tpl = template;
-
+  console.log('createPersistStore', name, fromStorage);
   if (fromStorage) {
     const storageCache = await storage.get(name);
+    console.log('storageCache', storageCache);
     tpl = storageCache || template;
     if (!storageCache) {
+      console.log('set storageCache', name, tpl);
       await storage.set(name, tpl);
     }
   }

--- a/src/ui/views/Approval/components/EthApproval/EthConnect/index.tsx
+++ b/src/ui/views/Approval/components/EthApproval/EthConnect/index.tsx
@@ -1,13 +1,11 @@
-import { Stack, Box, Typography, Divider, CardMedia, Card } from '@mui/material';
+import { Stack, Box, Typography, Divider, CardMedia } from '@mui/material';
 import React, { useCallback, useEffect, useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import { useLocation, useHistory } from 'react-router-dom';
 
 import { isValidEthereumAddress } from '@/shared/utils/address';
-import enableBg from 'ui/FRWAssets/image/enableBg.png';
+import { useProfiles } from '@/ui/hooks/useProfileHook';
 import flowgrey from 'ui/FRWAssets/svg/flow-grey.svg';
 import linkGlobe from 'ui/FRWAssets/svg/linkGlobe.svg';
-import { LLPrimaryButton, LLSecondaryButton, LLSpinner, LLConnectLoading } from 'ui/FRWComponent';
+import { LLPrimaryButton, LLSecondaryButton, LLConnectLoading } from 'ui/FRWComponent';
 import { useApproval, useWallet, formatAddress } from 'ui/utils';
 
 import CheckCircleIcon from '../../../../../../components/iconfont/IconCheckmark';
@@ -19,31 +17,42 @@ interface ConnectProps {
   params: any;
 }
 
+// The EthConnect component is used to connect to the dApp
+// The EthConnect component will show the user the request and allow or reject it
+
+// It is triggered by the eth_requestAccounts method
+// If the dApp has never connected to the wallet before, it will ask the user for permission to connect
+// If the dApp has connected to the wallet before, it will simply connect to the wallet
+// This ensures the wallet is logged in and ready to use with the dApp
+
+// Note that SortHat is the first page that is loaded when the approval notification is opened by the background
+// SortHat ensures the wallet is logged in and ready to use with the dApp
+
+// The Approval page is loaded if SortHat detects that the wallet is already logged in and the background has a pending approval
+// The Approval page looks at the approvalComponent in the background approval object
+// The Approval page then renders the corresponding component based on the approvalComponent
+
+// In this case, the approvalComponent is 'EthConnect'
+
 const EthConnect = ({ params: { icon, name, origin } }: ConnectProps) => {
-  const { state } = useLocation<{
-    showChainsModal?: boolean;
-  }>();
-  const { showChainsModal = false } = state ?? {};
+  // This is used to resolve or reject the approval in the background
   const [, resolveApproval, rejectApproval] = useApproval();
-  const { t } = useTranslation();
+  // This is used to interact with the wallet
   const usewallet = useWallet();
+
+  // This is used to show a loading spinner
   const [isLoading, setIsLoading] = useState(false);
 
-  const [appIdentifier, setAppIdentifier] = useState<string | undefined>(undefined);
-  const [nonce, setNonce] = useState<string | undefined>(undefined);
-  const [opener, setOpener] = useState<number | undefined>(undefined);
   const [defaultChain, setDefaultChain] = useState(747);
-  const [host, setHost] = useState('');
-  const [showMoveBoard, setMoveBoard] = useState(true);
-  const [msgNetwork, setMsgNetwork] = useState('testnet');
   const [isEvm, setIsEvm] = useState(false);
   const [currentNetwork, setCurrent] = useState('testnet');
-
-  const [approval, setApproval] = useState(false);
 
   // TODO: replace default logo
   const [logo, setLogo] = useState('');
   const [evmAddress, setEvmAddress] = useState('');
+
+  // This is used to initialize the component when the page is loaded
+
   const init = useCallback(async () => {
     const network = await usewallet.getNetwork();
     setCurrent(network);
@@ -114,6 +123,7 @@ const EthConnect = ({ params: { icon, name, origin } }: ConnectProps) => {
   );
 
   useEffect(() => {
+    // Handle listenting for transactionDone event
     chrome.runtime.onMessage.addListener(transactionDoneHandler);
 
     return () => {
@@ -122,10 +132,14 @@ const EthConnect = ({ params: { icon, name, origin } }: ConnectProps) => {
   }, [transactionDoneHandler]);
 
   const handleCancel = () => {
+    // This is called when the user clicks the cancel button
+    // This cancels the connection to the dApp
     rejectApproval('User rejected the request.');
   };
 
   const handleAllow = async () => {
+    // This is called when the user clicks the allow button
+    // This allows the connection to the dApp
     resolveApproval({
       defaultChain,
       signPermission: 'MAINNET_AND_TESTNET',

--- a/src/ui/views/Approval/index.tsx
+++ b/src/ui/views/Approval/index.tsx
@@ -16,7 +16,7 @@ const Approval = () => {
   const usewallet = useWallet();
   // const { initializeStore } = useInitHook();
   const [getApproval, resolveApproval, rejectApproval] = useApproval();
-  const [approval, setApproval] = useState<any>(null);
+  const [approval, setApproval] = useState<null | Awaited<ReturnType<typeof getApproval>>>(null);
 
   const init = useCallback(async () => {
     // initializeStore();

--- a/src/ui/views/Deposit/index.tsx
+++ b/src/ui/views/Deposit/index.tsx
@@ -132,7 +132,7 @@ const Deposit = () => {
         result.map((ele, idx) => ({
           id: idx,
           name: chrome.i18n.getMessage('Wallet'),
-          address: withPrefix(ele.blockchain[0].address),
+          address: withPrefix(ele?.blockchain[0]?.address),
         }))
       );
     } else if (isChild) {

--- a/src/ui/views/Setting/Wallet/index.tsx
+++ b/src/ui/views/Setting/Wallet/index.tsx
@@ -97,7 +97,7 @@ const Wallet = () => {
     const fectechdWallet = await fetchBalances(wallet);
     setCurrentWallet(currentWallet.address);
     const evmWallet = await usewallet.getEvmWallet();
-    const filteredEvm = [evmWallet].filter((evm) => evm.address);
+    const filteredEvm = [evmWallet].filter((evm) => evm?.address);
     if (filteredEvm.length > 0) {
       const fetchedEvm = await fetchEvmBalances(transformData(filteredEvm));
       setEvmList(fetchedEvm);


### PR DESCRIPTION
## Related Issue

Closes #600

## Summary of Changes

- Updated wallet unlock to load wallet addresses in the background - this was previously done in the foreground which caused a lot of problems
- eth_accounts no longer returns the EVM address if the wallet is locked
- eth_requestAccounts now properly checks if the wallet is locked and asks the user to unlock - even if the site was previously connected. If the site was previously connecting the dialog will close immediately after unlocking


## Need Regression Testing

- [X] Yes
- [ ] No

## Risk Assessment

This changes some of the core dApp connection code that hasn't been altered in years. 

- [ ] Low
- [ ] Medium
- [X] High

## Additional Notes
Please check opensea 2.0 and pumpflow in particular. Opensea 2 had issues reconnecting

