### PR TITLE
Updated ethAccounts handling

### DIFF
--- a/src/background/controller/provider/controller.ts
+++ b/src/background/controller/provider/controller.ts
@@ -288,7 +288,6 @@ class ProviderController extends BaseController {
     return result;
   };
 
-  @Reflect.metadata('SAFE', true)
   ethAccounts = async ({ session: { origin } }) => {
     if (!permissionService.hasPermission(origin) || !Wallet.isUnlocked()) {
       return [];

--- a/src/background/controller/provider/controller.ts
+++ b/src/background/controller/provider/controller.ts
@@ -288,6 +288,7 @@ class ProviderController extends BaseController {
     return result;
   };
 
+  @Reflect.metadata('SAFE', true)
   ethAccounts = async ({ session: { origin } }) => {
     if (!permissionService.hasPermission(origin) || !Wallet.isUnlocked()) {
       return [];

--- a/src/background/controller/provider/rpcFlow.ts
+++ b/src/background/controller/provider/rpcFlow.ts
@@ -58,7 +58,11 @@ const flowContext = flow
     console.log('flow - use #2 - check connect', mapMethod, origin, name, icon);
 
     // check connect
-    if (!Reflect.getMetadata('SAFE', providerController, mapMethod)) {
+    // TODO: create a whitelist and list of safe methods to remove the need for Reflect.getMetadata
+    if (
+      mapMethod !== 'ethAccounts' &&
+      !Reflect.getMetadata('SAFE', providerController, mapMethod)
+    ) {
       if (!permissionService.hasPermission(origin)) {
         ctx.request.requestedApproval = true;
         const { defaultChain, signPermission } = await notificationService.requestApproval(

--- a/src/background/controller/provider/rpcFlow.ts
+++ b/src/background/controller/provider/rpcFlow.ts
@@ -29,6 +29,8 @@ const flowContext = flow
     const {
       data: { method },
     } = ctx.request;
+    console.log('flow - use #1', method);
+
     ctx.mapMethod = underline2Camelcase(method);
     if (!providerController[ctx.mapMethod]) {
       // TODO: make rpc whitelist
@@ -46,7 +48,6 @@ const flowContext = flow
 
     return next();
   })
-
   .use(async (ctx, next) => {
     const {
       request: {
@@ -54,6 +55,8 @@ const flowContext = flow
       },
       mapMethod,
     } = ctx;
+    console.log('flow - use #2 - check connect', mapMethod, origin, name, icon);
+
     // check connect
     if (!Reflect.getMetadata('SAFE', providerController, mapMethod)) {
       if (!permissionService.hasPermission(origin)) {
@@ -80,6 +83,8 @@ const flowContext = flow
       },
       mapMethod,
     } = ctx;
+    console.log('flow - use #3 - check approval', mapMethod, origin, name, icon);
+
     const [approvalType, condition, { height = 599 } = {}] =
       Reflect.getMetadata('APPROVAL', providerController, mapMethod) || [];
     if (mapMethod === 'ethSendTransaction' || mapMethod === 'personalSign') {
@@ -107,6 +112,8 @@ const flowContext = flow
   })
   .use(async (ctx) => {
     const { approvalRes, mapMethod, request } = ctx;
+    console.log('flow - use #4 - process request', mapMethod, request);
+
     // process request
     const [approvalType] = Reflect.getMetadata('APPROVAL', providerController, mapMethod) || [];
     const { uiRequestComponent, ...rest } = approvalRes || {};
@@ -122,6 +129,7 @@ const flowContext = flow
 
     requestDefer
       .then((result) => {
+        console.log('flow - process result', mapMethod, result);
         if (isSignApproval(approvalType)) {
           eventBus.emit(EVENTS.broadcastToUI, {
             method: EVENTS.SIGN_FINISHED,
@@ -134,6 +142,8 @@ const flowContext = flow
         return result;
       })
       .catch((e: any) => {
+        console.log('flow - process error', mapMethod, e);
+
         if (isSignApproval(approvalType)) {
           eventBus.emit(EVENTS.broadcastToUI, {
             method: EVENTS.SIGN_FINISHED,

--- a/src/background/service/userWallet.ts
+++ b/src/background/service/userWallet.ts
@@ -151,7 +151,6 @@ class UserWallet {
     network: string,
     index = null
   ) => {
-    console.log('setCurrentWallet', wallet, key, network, index);
     if (key && key !== 'evm') {
       this.store.currentWallet = wallet;
     } else if (key === 'evm') {
@@ -282,14 +281,10 @@ class UserWallet {
     if (this.isLocked()) {
       return null;
     }
-    console.log('getEvmWallet', this.store.evmWallet, storage.get('evmWallet'));
     return this.store.evmWallet;
-
-    //   return { ...this.store.evmWallet };
   };
 
   setEvmAddress = (address: string, emoji) => {
-    console.log('setEvmAddress', address, emoji);
     if (address.length > 20) {
       this.store.evmWallet.address = address;
       this.store.evmWallet.name = emoji[9].name;

--- a/src/background/utils/persisitStore.ts
+++ b/src/background/utils/persisitStore.ts
@@ -1,11 +1,6 @@
-import debounce from 'debounce';
-
 import { storage } from 'background/webapi';
 
 const persistStorage = (name: string, obj: object) => {
-  //  if (name === 'userWallets') {
-  console.log('persistStorage', name, JSON.parse(JSON.stringify(obj)));
-  //x}
   storage.set(name, obj);
 };
 
@@ -21,13 +16,10 @@ const createPersistStore = async <T extends object>({
   fromStorage = true,
 }: CreatePersistStoreParams<T>): Promise<T> => {
   let tpl = template;
-  console.log('createPersistStore', name, fromStorage);
   if (fromStorage) {
     const storageCache = await storage.get(name);
-    console.log('storageCache', storageCache);
     tpl = storageCache || template;
     if (!storageCache) {
-      console.log('set storageCache', name, tpl);
       await storage.set(name, tpl);
     }
   }


### PR DESCRIPTION
## Related Issue

Closes #600

## Summary of Changes

Marked ethAccounts as SAFE - the method handles not being logged in. This fixes the problem where the wallet was popping up when visiting sites like kittypunch punchswap. Added some logging to the rpcFlow for debugging. removed logging for evm accounts and persiststorage

## Need Regression Testing

- [X] Yes
- [ ] No

## Risk Assessment

- [ ] Low
- [X] Medium
- [ ] High

