### PR TITLE
Fix: now requires explicit connection approval after unlocking

### DIFF
--- a/src/background/controller/provider/controller.ts
+++ b/src/background/controller/provider/controller.ts
@@ -206,7 +206,7 @@ class ProviderController extends BaseController {
   };
 
   ethRequestAccounts = async ({ session: { origin, name, icon } }) => {
-    if (!permissionService.hasPermission(origin) || !Wallet.isUnlocked()) {
+    if (!permissionService.hasPermission(origin) || !(await Wallet.isUnlocked())) {
       const { defaultChain, signPermission } = await notificationService.requestApproval(
         {
           params: { origin, name, icon },
@@ -289,7 +289,7 @@ class ProviderController extends BaseController {
   };
 
   ethAccounts = async ({ session: { origin } }) => {
-    if (!permissionService.hasPermission(origin) || !Wallet.isUnlocked()) {
+    if (!permissionService.hasPermission(origin) || !(await Wallet.isUnlocked())) {
       return [];
     }
 

--- a/src/background/controller/provider/rpcFlow.ts
+++ b/src/background/controller/provider/rpcFlow.ts
@@ -61,9 +61,16 @@ const flowContext = flow
     // TODO: create a whitelist and list of safe methods to remove the need for Reflect.getMetadata
     if (
       mapMethod !== 'ethAccounts' &&
+      mapMethod !== 'walletRequestPermissions' &&
+      mapMethod !== 'walletRevokePermissions' &&
+      mapMethod !== 'walletSwitchEthereumChain' &&
+      mapMethod !== 'walletWatchAsset' &&
+      mapMethod !== 'walletConnect' &&
+      mapMethod !== 'walletDisconnect' &&
+      mapMethod !== 'walletConnect' &&
       !Reflect.getMetadata('SAFE', providerController, mapMethod)
     ) {
-      if (!permissionService.hasPermission(origin)) {
+      if (!permissionService.hasPermission(origin) || !(await Wallet.isUnlocked())) {
         ctx.request.requestedApproval = true;
         const { defaultChain, signPermission } = await notificationService.requestApproval(
           {

--- a/src/background/service/notification.ts
+++ b/src/background/service/notification.ts
@@ -86,7 +86,10 @@ class NotificationService extends Events {
     } else {
       this.approval?.resolve(data);
     }
-    this.approval = null;
+    // Handle the case where the approval is not unlocked
+    if (data !== 'unlocked') {
+      this.approval = null;
+    }
     this.emit('resolve', data);
   };
 

--- a/src/background/service/notification.ts
+++ b/src/background/service/notification.ts
@@ -87,15 +87,16 @@ class NotificationService extends Events {
       this.approval?.resolve(data);
     }
     // Handle the case where the approval is not unlocked
-    if (data !== 'unlocked') {
-      this.approval = null;
-    }
+    this.approval = null;
     this.emit('resolve', data);
   };
 
   rejectApproval = async (err?: string) => {
-    // this.approval?.reject(ethErrors.provider.userRejectedRequest<any>(err));
+    // Reject the approval
+    this.approval?.reject(ethErrors.provider.userRejectedRequest<any>(err));
+    // Clear the approval
     await this.clear();
+    // Emit the reject event
     this.emit('reject', err);
   };
 

--- a/src/ui/component/PrivateRoute.tsx
+++ b/src/ui/component/PrivateRoute.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { Route, Redirect } from 'react-router-dom';
+import { Route, Redirect, useRouteMatch } from 'react-router-dom';
 
 import { useWallet } from 'ui/utils';
 
-const PrivateRoute = ({ children, ...rest }) => {
+const PrivateRoute = ({ children, path, ...rest }) => {
   const wallet = useWallet();
+  const match = useRouteMatch(path);
+
   const [booted, setBooted] = useState(false);
   const [unlocked, setUnlocked] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -24,21 +26,26 @@ const PrivateRoute = ({ children, ...rest }) => {
       }
     };
 
-    fetchLockState().then(({ booted, unlocked }) => {
-      if (mounted) {
-        setBooted(booted);
-        setUnlocked(unlocked);
-        setLoading(false);
-      }
-    });
+    //const strippedPath = path.replace(/\/$/, '');
 
+    // Initial check
+    if (match?.isExact) {
+      fetchLockState().then(({ booted, unlocked }) => {
+        if (mounted) {
+          setBooted(booted);
+          setUnlocked(unlocked);
+          setLoading(false);
+        }
+      });
+    }
     return () => {
       mounted = false;
     };
-  }, [wallet]);
+  }, [wallet, match?.isExact]);
 
   return (
     <Route
+      path={path}
       {...rest}
       render={() => {
         if (loading) {

--- a/src/ui/views/Unlock/index.tsx
+++ b/src/ui/views/Unlock/index.tsx
@@ -1,5 +1,5 @@
 // import { useTranslation } from 'react-i18next';
-import { Input, Typography, Box, FormControl } from '@mui/material';
+import { Input, Typography, Box, FormControl, CircularProgress } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
@@ -64,6 +64,7 @@ const Unlock = () => {
   const [showError, setShowError] = useState(false);
   const [password, setPassword] = useState(DEFAULT_PASSWORD);
   const [resetPop, setResetPop] = useState<boolean>(false);
+  const [unlocking, setUnlocking] = useState<boolean>(false);
   const { clearProfileData } = useProfiles();
 
   useEffect(() => {
@@ -78,30 +79,27 @@ const Unlock = () => {
     openInternalPageInTab('forgot');
   }, [wallet, clearProfileData]);
 
-  const [run] = useWalletRequest(wallet.unlock, {
-    onSuccess() {
-      // Always go to the index page so that SortHat can figure out any approvals
-      // Resolving an approval here will not work because the user has not yet approved the request
+  const handleUnlock = useCallback(async () => {
+    try {
+      setUnlocking(true);
+      await wallet.unlock(password);
       history.replace('/');
-    },
-    onError(err) {
-      console.error('onError', err);
+    } catch (err) {
+      console.error(err);
       setShowError(true);
-    },
-  });
+    } finally {
+      setUnlocking(false);
+    }
+  }, [wallet, history, password]);
 
   const handleKeyDown = useCallback(
     (event) => {
       if (event.key === 'Enter') {
-        run(password);
+        handleUnlock();
       }
     },
-    [run, password]
+    [handleUnlock]
   );
-
-  const handleUnlock = useCallback(() => {
-    run(password);
-  }, [run, password]);
 
   return (
     <Box
@@ -184,8 +182,10 @@ const Unlock = () => {
           type="submit"
           onClick={handleUnlock}
           fullWidth
-          label={chrome.i18n.getMessage('Unlock_Wallet')}
-          disabled={!walletIsLoaded}
+          label={
+            unlocking ? <CircularProgress size={18} /> : chrome.i18n.getMessage('Unlock_Wallet')
+          }
+          disabled={!walletIsLoaded || unlocking}
 
           // sx={{marginTop: '40px', height: '48px'}}
           // type="primary"

--- a/src/ui/views/Unlock/index.tsx
+++ b/src/ui/views/Unlock/index.tsx
@@ -2,6 +2,7 @@
 import { Input, Typography, Box, FormControl } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 
 import lilo from '@/ui/FRWAssets/image/lilo.png';
 import { LLPrimaryButton, LLResetPopup } from '@/ui/FRWComponent';
@@ -56,8 +57,8 @@ const DEFAULT_PASSWORD =
 const Unlock = () => {
   const wallet = useWallet();
   const walletIsLoaded = useWalletLoaded();
+  const history = useHistory();
   const classes = useStyles();
-  const [, resolveApproval] = useApproval();
   const inputEl = useRef<any>(null);
   // const { t } = useTranslation();
   const [showError, setShowError] = useState(false);
@@ -79,7 +80,9 @@ const Unlock = () => {
 
   const [run] = useWalletRequest(wallet.unlock, {
     onSuccess() {
-      resolveApproval('unlocked');
+      // Always go to the index page so that SortHat can figure out any approvals
+      // Resolving an approval here will not work because the user has not yet approved the request
+      history.replace('/');
     },
     onError(err) {
       console.error('onError', err);


### PR DESCRIPTION
## Related Issue

Closes #600

## Summary of Changes

No longer clears notification after unlock. PrivateRoute now checks if matching route before looking at whether wallet is unlocked. Now properly waits for the result of wallet.isUnlocked. No longer blindly resolves approval after unlocking. Properly sends cancel / reject messages back to dApp. No longer requests approval for events that don't require it

## Need Regression Testing

Affects dApp login

- [X] Yes
- [ ] No

## Risk Assessment


- [ ] Low
- [X] Medium
- [ ] High

