### PR TITLE
728-feature-speed-up-e2e-tests

### DIFF
--- a/e2e/balance-transaction.test.ts
+++ b/e2e/balance-transaction.test.ts
@@ -1,0 +1,80 @@
+import BN from 'bignumber.js';
+
+import { switchToEvm, loginToSenderAccount, loginToReceiverAccount } from './utils/helper';
+import { test, expect } from './utils/loader';
+
+// Define minimum required balances for each token
+const REQUIRED_BALANCES_CADENCE = {
+  flow: '0.01', // Sum of Flow transactions in Cadence (0.00123456 * 3) plus buffer
+  stFlow: '0.002', // stFlow requirement (0.00123456) plus buffer
+  'usdc.e': '0.002', // USDC requirement (0.00123456) plus buffer
+  beta: '0.002', // BETA requirement (0.00123456) plus buffer
+};
+
+const REQUIRED_BALANCES_EVM = {
+  flow: '0.15', // Sum of Flow transactions in EVM (0.12345678 + 0.00123456 * 2) plus buffer
+  stFlow: '0.000002', // stFlow requirement (0.00000112134354678) plus buffer
+  'usdc.e': '0.003', // Bridged USDC requirement (0.002468) plus buffer
+  beta: '0.002', // BETA requirement (0.001234567890123456) plus buffer
+};
+
+const getTokenBalance = async (page, tokenName: string): Promise<string> => {
+  await page.getByRole('tab', { name: 'coins' }).click();
+
+  // Get the balance from the token detail view
+  const balanceText = await page
+    .getByTestId(`coin-balance-${tokenName.toLowerCase()}`)
+    .textContent();
+
+  // Extract just the number from the balance text
+  const balance = balanceText?.match(/[\d.]+/)?.[0] || '0';
+  return balance;
+};
+
+const checkTokenBalance = (tokenName: string, actualBalance: string, requiredBalance: string) => {
+  const actual = new BN(actualBalance);
+  const required = new BN(requiredBalance);
+
+  expect(
+    actual.gte(required),
+    `Insufficient ${tokenName} balance. Required: ${requiredBalance}, Actual: ${actualBalance}`
+  ).toBeTruthy();
+};
+
+test('Verify sufficient token balances for sender account', async ({ page, extensionId }) => {
+  // Login to sender account
+  await loginToSenderAccount({ page, extensionId });
+
+  // First check Cadence wallet balances
+  for (const [tokenName, requiredBalance] of Object.entries(REQUIRED_BALANCES_CADENCE)) {
+    const balance = await getTokenBalance(page, tokenName);
+    checkTokenBalance(tokenName, balance, requiredBalance);
+  }
+
+  // Switch to EVM wallet and check balances
+  await switchToEvm({ page, extensionId });
+  for (const [tokenName, requiredBalance] of Object.entries(REQUIRED_BALANCES_EVM)) {
+    const balance = await getTokenBalance(page, tokenName);
+    checkTokenBalance(tokenName, balance, requiredBalance);
+  }
+  console.log('Sender balance verified...');
+});
+
+test('Verify sufficient token balances for receiver account', async ({ page, extensionId }) => {
+  // Login to sender account
+  await loginToReceiverAccount({ page, extensionId });
+
+  // First check Cadence wallet balances
+  for (const [tokenName, requiredBalance] of Object.entries(REQUIRED_BALANCES_CADENCE)) {
+    const balance = await getTokenBalance(page, tokenName);
+    checkTokenBalance(tokenName, balance, requiredBalance);
+  }
+
+  // Switch to EVM wallet and check balances
+  await switchToEvm({ page, extensionId });
+  for (const [tokenName, requiredBalance] of Object.entries(REQUIRED_BALANCES_EVM)) {
+    const balance = await getTokenBalance(page, tokenName);
+    checkTokenBalance(tokenName, balance, requiredBalance);
+  }
+  console.log('Receiver balance verified...');
+});

--- a/e2e/cadence-transaction.test.ts
+++ b/e2e/cadence-transaction.test.ts
@@ -1,4 +1,5 @@
-import { test, loginToSenderAccount, getCurrentAddress, waitForTransaction } from './utils/helper';
+import { loginToSenderAccount, getCurrentAddress, waitForTransaction } from './utils/helper';
+import { test } from './utils/loader';
 export const sendTokenFlow = async ({
   page,
   tokenname,

--- a/e2e/cadence-transaction.test.ts
+++ b/e2e/cadence-transaction.test.ts
@@ -1,4 +1,10 @@
-import { loginToSenderAccount, getCurrentAddress, waitForTransaction } from './utils/helper';
+import {
+  getCurrentAddress,
+  waitForTransaction,
+  loginToSenderOrReceiver,
+  getReceiverEvmAccount,
+  getReceiverCadenceAccount,
+} from './utils/helper';
 import { test } from './utils/loader';
 export const sendTokenFlow = async ({
   page,
@@ -60,7 +66,7 @@ export const moveTokenFlowHomepage = async ({
 
 test.beforeEach(async ({ page, extensionId }) => {
   // Login to our sender account
-  await loginToSenderAccount({ page, extensionId });
+  await loginToSenderOrReceiver({ page, extensionId, parallelIndex: test.info().parallelIndex });
 });
 //Send FLOW token from Flow to Flow
 test('send FLOW flow to flow', async ({ page }) => {
@@ -68,7 +74,7 @@ test('send FLOW flow to flow', async ({ page }) => {
   await sendTokenFlow({
     page,
     tokenname: /^FLOW \$/i,
-    receiver: process.env.TEST_RECEIVER_ADDR!,
+    receiver: getReceiverCadenceAccount({ parallelIndex: test.info().parallelIndex }),
     amount: '0.00123456',
   });
 });
@@ -78,7 +84,7 @@ test('send stFlow flow to flow', async ({ page }) => {
   await sendTokenFlow({
     page,
     tokenname: 'Liquid Staked Flow $',
-    receiver: process.env.TEST_RECEIVER_ADDR!,
+    receiver: getReceiverCadenceAccount({ parallelIndex: test.info().parallelIndex }),
     amount: '0.00123456',
   });
 });
@@ -86,10 +92,11 @@ test('send stFlow flow to flow', async ({ page }) => {
 //Send FLOW token from Flow to COA
 test('send FLOW flow to COA', async ({ page }) => {
   // This can take a while
+
   await sendTokenFlow({
     page,
     tokenname: /^FLOW \$/i,
-    receiver: process.env.TEST_RECEIVER_EVM_ADDR!,
+    receiver: getReceiverEvmAccount({ parallelIndex: test.info().parallelIndex }),
     amount: '0.00123456',
   });
 });
@@ -98,7 +105,7 @@ test('send USDC flow to COA', async ({ page }) => {
   await sendTokenFlow({
     page,
     tokenname: 'USDC.e (Flow) $',
-    receiver: process.env.TEST_RECEIVER_EVM_ADDR!,
+    receiver: getReceiverEvmAccount({ parallelIndex: test.info().parallelIndex }),
     ingoreFlowCharge: true,
     amount: '0.00123456',
   });

--- a/e2e/evm-transaction.test.ts
+++ b/e2e/evm-transaction.test.ts
@@ -1,10 +1,11 @@
 import {
-  test,
   loginToSenderAccount,
   getCurrentAddress,
   switchToEvm,
   waitForTransaction,
 } from './utils/helper';
+import { test } from './utils/loader';
+
 export const sendTokenCOA = async ({
   page,
   tokenname,

--- a/e2e/evm-transaction.test.ts
+++ b/e2e/evm-transaction.test.ts
@@ -3,6 +3,9 @@ import {
   getCurrentAddress,
   switchToEvm,
   waitForTransaction,
+  loginToSenderOrReceiver,
+  getReceiverEvmAccount,
+  getReceiverCadenceAccount,
 } from './utils/helper';
 import { test } from './utils/loader';
 
@@ -61,7 +64,7 @@ export const moveTokenCoaHomepage = async ({ page, tokenname, amount = '0.000000
 
 test.beforeEach(async ({ page, extensionId }) => {
   // Login to our sender account
-  await loginToSenderAccount({ page, extensionId });
+  await loginToSenderOrReceiver({ page, extensionId, parallelIndex: test.info().parallelIndex });
   // switch to EVM account
   await switchToEvm({ page, extensionId });
 });
@@ -71,7 +74,7 @@ test('send Flow COA to COA', async ({ page }) => {
   await sendTokenCOA({
     page,
     tokenname: /^FLOW \$/i,
-    receiver: process.env.TEST_RECEIVER_EVM_ADDR!,
+    receiver: getReceiverEvmAccount({ parallelIndex: test.info().parallelIndex }),
     successtext: 'success',
     amount: '0.12345678', // 8 decimal places
   });
@@ -82,7 +85,7 @@ test('send Staked Flow COA to COA', async ({ page }) => {
   await sendTokenCOA({
     page,
     tokenname: 'Liquid Staked Flow $',
-    receiver: process.env.TEST_RECEIVER_EVM_ADDR!,
+    receiver: getReceiverEvmAccount({ parallelIndex: test.info().parallelIndex }),
     successtext: 'success',
     amount: '0.00000112134354678',
   });
@@ -95,7 +98,7 @@ test('send Flow COA to FLOW', async ({ page }) => {
   await sendTokenCOA({
     page,
     tokenname: /^FLOW \$/i,
-    receiver: process.env.TEST_RECEIVER_ADDR!,
+    receiver: getReceiverCadenceAccount({ parallelIndex: test.info().parallelIndex }),
     successtext: 'success',
     amount: '0.00123456', // 8 decimal places
   });
@@ -106,7 +109,7 @@ test('send USDC token COA to FLOW', async ({ page }) => {
   await sendTokenCOA({
     page,
     tokenname: 'Bridged USDC (Celer) $',
-    receiver: process.env.TEST_RECEIVER_ADDR!,
+    receiver: getReceiverCadenceAccount({ parallelIndex: test.info().parallelIndex }),
     successtext: 'success',
     amount: '0.002468', // 6 decimal places
   });

--- a/e2e/login.test.ts
+++ b/e2e/login.test.ts
@@ -1,4 +1,5 @@
-import { test, loginAsTestUser } from './utils/helper';
+import { loginAsTestUser } from './utils/helper';
+import { test } from './utils/loader';
 
 test('Login test', async ({ page, extensionId }) => {
   await loginAsTestUser({ page, extensionId });

--- a/e2e/login.test.ts
+++ b/e2e/login.test.ts
@@ -1,5 +1,26 @@
-import { loginAsTestUser } from './utils/helper';
+import { loginAsTestUser, registerTestUser } from './utils/helper';
 import { test } from './utils/loader';
+
+test.beforeAll(async ({ page, extensionId }) => {
+  // let playwright know this is going to be slow
+  // Wait up to 10 minutes to setup an account
+  test.setTimeout(600_000);
+  // Create a new page and navigate to extension
+  // Navigate and wait for network to be idle
+  await page.goto(`chrome-extension://${extensionId}/index.html#/dashboard`);
+
+  await page.waitForLoadState('domcontentloaded');
+
+  await page.waitForURL(/.*unlock|.*welcome/);
+  const pageUrl = page.url();
+  const isWelcomePage = pageUrl.includes('welcome');
+
+  // Create or login using our test user
+  if (isWelcomePage) {
+    // We're not starting from a fresh install, so login
+    await registerTestUser({ page, extensionId });
+  }
+});
 
 test('Login test', async ({ page, extensionId }) => {
   await loginAsTestUser({ page, extensionId });

--- a/e2e/utils/helper.ts
+++ b/e2e/utils/helper.ts
@@ -47,7 +47,10 @@ export const loginToExtensionAccount = async ({ page, extensionId, addr, passwor
   await closeOpenedPages(page);
 
   // Navigate and wait for network to be idle
-  await page.goto(`chrome-extension://${extensionId}/index.html#/unlock`);
+  await page.goto(`chrome-extension://${extensionId}/index.html#/dashboard`);
+
+  // Wait to be redirected to the unlock page
+  await page.waitForURL(/.*\/unlock.*/);
 
   await page.waitForSelector('.logoContainer', { state: 'visible' });
   await closeOpenedPages(page);

--- a/e2e/utils/helper.ts
+++ b/e2e/utils/helper.ts
@@ -47,10 +47,7 @@ export const loginToExtensionAccount = async ({ page, extensionId, addr, passwor
   await closeOpenedPages(page);
 
   // Navigate and wait for network to be idle
-  await page.goto(`chrome-extension://${extensionId}/index.html#/dashboard`);
-
-  // Wait to be redirected to the unlock page
-  await page.waitForURL(/.*\/unlock.*/);
+  await page.goto(`chrome-extension://${extensionId}/index.html#/unlock`);
 
   await page.waitForSelector('.logoContainer', { state: 'visible' });
   await closeOpenedPages(page);

--- a/e2e/utils/loader.ts
+++ b/e2e/utils/loader.ts
@@ -33,6 +33,7 @@ export const test = base.extend<{
     if (!isSetup) {
       // Copy the base folder to a new folder with the parallel index
       dataDir = `${baseFolderName}-${process.env.TEST_PARALLEL_INDEX}`;
+
       fs.cpSync(baseFolderName, dataDir, { recursive: true });
     }
 
@@ -120,3 +121,5 @@ export const getAuth = async () => {
 export const cleanAuth = async () => {
   await saveAuth(null);
 };
+
+export const expect = test.expect;

--- a/e2e/utils/loader.ts
+++ b/e2e/utils/loader.ts
@@ -1,0 +1,94 @@
+import fs from 'fs';
+import path from 'path';
+
+import base, { type BrowserContext, chromium } from '@playwright/test';
+
+const getKeysFilePath = (workerIndex: string | number | undefined) => {
+  if (!workerIndex) {
+    throw new Error('TEST_PARALLEL_INDEX is not set');
+  }
+  return path.join(import.meta.dirname, `../../playwright/.auth/keys-${workerIndex}.json`);
+};
+
+export const test = base.extend<{
+  context: BrowserContext;
+  extensionId: string;
+}>({
+  context: async ({}, call) => {
+    const pathToExtension = path.join(import.meta.dirname, '../../dist');
+    const context = await chromium.launchPersistentContext(
+      `/tmp/test-user-data-dir-${process.env.TEST_PARALLEL_INDEX}`,
+      {
+        channel: 'chromium',
+        args: [
+          `--disable-extensions-except=${pathToExtension}`,
+          `--load-extension=${pathToExtension}`,
+          '--allow-read-clipboard',
+          '--allow-write-clipboard',
+        ],
+        env: {
+          ...process.env,
+          TEST_MODE: 'true',
+        },
+        permissions: ['clipboard-read', 'clipboard-write'],
+      }
+    );
+
+    await call(context);
+    await context.close();
+  },
+  extensionId: async ({ context }, call) => {
+    // for manifest v3:
+    let [background] = context.serviceWorkers();
+    if (!background) background = await context.waitForEvent('serviceworker');
+    const extensionId = background.url().split('/')[2];
+    await call(extensionId);
+  },
+});
+
+export const cleanExtension = async () => {
+  console.log(
+    'Cleaning extension for - parallel index, worker index, project',
+    process.env.TEST_PARALLEL_INDEX,
+    process.env.TEST_WORKER_INDEX,
+    process.env.TEST_PROJECT
+  );
+
+  const userDataDir = `/tmp/test-user-data-dir-${process.env.TEST_PARALLEL_INDEX}`;
+  if (fs.existsSync(userDataDir)) {
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  }
+};
+
+// save keys auth file
+
+export const saveAuth = async (auth) => {
+  const keysFilePath = getKeysFilePath(process.env.TEST_PARALLEL_INDEX);
+
+  if (auth) {
+    // Ensure directory exists
+
+    const dirPath = path.dirname(keysFilePath);
+    fs.mkdirSync(dirPath, { recursive: true });
+    fs.writeFileSync(keysFilePath, JSON.stringify(auth));
+  } else {
+    if (fs.existsSync(keysFilePath)) {
+      fs.unlinkSync(keysFilePath);
+    }
+  }
+};
+// get keys auth file
+
+export const getAuth = async () => {
+  const keysFilePath = getKeysFilePath(process.env.TEST_PARALLEL_INDEX);
+  const keysFileContent = fs.existsSync(keysFilePath)
+    ? fs.readFileSync(keysFilePath, 'utf8')
+    : null;
+  const keysFile = keysFileContent ? JSON.parse(keysFileContent) : null;
+  return keysFile || { password: '', addr: '' };
+};
+// delete keys file
+
+export const cleanAuth = async () => {
+  await saveAuth(null);
+};

--- a/e2e/utils/loader.ts
+++ b/e2e/utils/loader.ts
@@ -27,9 +27,9 @@ export const test = base.extend<{
 
     const baseFolderName = `/tmp/test-user-data-dir-${isTransaction ? 'transaction' : isRegistration ? 'registration' : 'other'}`;
     let dataDir = baseFolderName;
-    if (!isSetup) {
+    if (!isSetup && !isRegistration) {
       // Copy the base folder to a new folder with the parallel index
-      dataDir = `${baseFolderName}-${process.env.TEST_PARALLEL_INDEX}`;
+      dataDir = `${baseFolderName}-${process.env.TEST_WORKER_INDEX}`;
 
       fs.cpSync(baseFolderName, dataDir, { recursive: true });
     }

--- a/e2e/utils/loader.ts
+++ b/e2e/utils/loader.ts
@@ -3,11 +3,8 @@ import path from 'path';
 
 import base, { type BrowserContext, chromium } from '@playwright/test';
 
-const getKeysFilePath = (workerIndex: string | number | undefined) => {
-  if (!workerIndex) {
-    throw new Error('TEST_PARALLEL_INDEX is not set');
-  }
-  return path.join(import.meta.dirname, `../../playwright/.auth/keys-${workerIndex}.json`);
+const getKeysFilePath = () => {
+  return path.join(import.meta.dirname, `../../playwright/.auth/keys.json`);
 };
 
 export const test = base.extend<{
@@ -92,7 +89,7 @@ export const cleanExtension = async (projectName: string) => {
 // save keys auth file
 
 export const saveAuth = async (auth) => {
-  const keysFilePath = getKeysFilePath(process.env.TEST_PARALLEL_INDEX);
+  const keysFilePath = getKeysFilePath();
 
   if (auth) {
     // Ensure directory exists
@@ -109,7 +106,7 @@ export const saveAuth = async (auth) => {
 // get keys auth file
 
 export const getAuth = async () => {
-  const keysFilePath = getKeysFilePath(process.env.TEST_PARALLEL_INDEX);
+  const keysFilePath = getKeysFilePath();
   const keysFileContent = fs.existsSync(keysFilePath)
     ? fs.readFileSync(keysFilePath, 'utf8')
     : null;

--- a/e2e/utils/registration.setup.ts
+++ b/e2e/utils/registration.setup.ts
@@ -1,0 +1,26 @@
+import { loginAsTestUser, registerTestUser } from './helper';
+import { test as setup } from './loader';
+
+// for user register and login
+setup('setup new wallet or login if already registered', async ({ page, extensionId }) => {
+  // let playwright know this is going to be slow
+  // Wait up to 10 minutes to setup an account
+  setup.setTimeout(600000);
+  // Create a new page and navigate to extension
+  // Navigate and wait for network to be idle
+  await page.goto(`chrome-extension://${extensionId}/index.html#/dashboard`);
+
+  await page.waitForLoadState('domcontentloaded');
+
+  await page.waitForURL(/.*unlock|.*welcome/);
+  const pageUrl = page.url();
+  const isUnlockPage = pageUrl.includes('unlock');
+
+  // Create or login using our test user
+  if (isUnlockPage) {
+    // We're not starting from a fresh install, so login
+    await loginAsTestUser({ page, extensionId });
+  } else {
+    await registerTestUser({ page, extensionId });
+  }
+});

--- a/e2e/utils/registration.setup.ts
+++ b/e2e/utils/registration.setup.ts
@@ -3,24 +3,5 @@ import { test as setup } from './loader';
 
 // for user register and login
 setup('setup new wallet or login if already registered', async ({ page, extensionId }) => {
-  // let playwright know this is going to be slow
-  // Wait up to 10 minutes to setup an account
-  setup.setTimeout(600000);
-  // Create a new page and navigate to extension
-  // Navigate and wait for network to be idle
   await page.goto(`chrome-extension://${extensionId}/index.html#/dashboard`);
-
-  await page.waitForLoadState('domcontentloaded');
-
-  await page.waitForURL(/.*unlock|.*welcome/);
-  const pageUrl = page.url();
-  const isUnlockPage = pageUrl.includes('unlock');
-
-  // Create or login using our test user
-  if (isUnlockPage) {
-    // We're not starting from a fresh install, so login
-    await loginAsTestUser({ page, extensionId });
-  } else {
-    await registerTestUser({ page, extensionId });
-  }
 });

--- a/e2e/utils/registration.setup.ts
+++ b/e2e/utils/registration.setup.ts
@@ -1,4 +1,3 @@
-import { loginAsTestUser, registerTestUser } from './helper';
 import { test as setup } from './loader';
 
 // for user register and login

--- a/e2e/utils/registration.teardown.ts
+++ b/e2e/utils/registration.teardown.ts
@@ -1,0 +1,10 @@
+// Just import from playwright as we don't want to load the extension from the temp directory
+import { test as teardown } from '@playwright/test';
+
+import { cleanAuth, cleanExtension } from './loader';
+
+teardown('cleanup registration keys', async () => {
+  //   Create a new page and navigate to extension
+  await cleanAuth();
+  await cleanExtension();
+});

--- a/e2e/utils/registration.teardown.ts
+++ b/e2e/utils/registration.teardown.ts
@@ -6,5 +6,5 @@ import { cleanAuth, cleanExtension } from './loader';
 teardown('cleanup registration keys', async () => {
   //   Create a new page and navigate to extension
   await cleanAuth();
-  await cleanExtension();
+  await cleanExtension('registration');
 });

--- a/e2e/utils/transaction.setup.ts
+++ b/e2e/utils/transaction.setup.ts
@@ -1,9 +1,6 @@
 import BN from 'bignumber.js';
 
 import {
-  test as setup,
-  loginAsTestUser,
-  registerTestUser,
   importReceiverAccount,
   importSenderAccount,
   lockExtension,
@@ -11,6 +8,7 @@ import {
   switchToEvm,
   loginToSenderAccount,
 } from './helper';
+import { test as setup } from './loader';
 
 // Define minimum required balances for each token
 const REQUIRED_BALANCES_CADENCE = {
@@ -49,31 +47,6 @@ const checkTokenBalance = (tokenName: string, actualBalance: string, requiredBal
     `Insufficient ${tokenName} balance. Required: ${requiredBalance}, Actual: ${actualBalance}`
   ).toBeTruthy();
 };
-
-// for user register and login
-setup('setup new wallet or login if already registered', async ({ page, extensionId }) => {
-  // let playwright know this is going to be slow
-  // Wait up to 10 minutes to setup an account
-  setup.setTimeout(600_000);
-  // Create a new page and navigate to extension
-  // Navigate and wait for network to be idle
-
-  await page.goto(`chrome-extension://${extensionId}/index.html#/dashboard`);
-
-  await page.waitForLoadState('domcontentloaded');
-
-  await page.waitForURL(/.*unlock|.*welcome/);
-  const pageUrl = page.url();
-  const isUnlockPage = pageUrl.includes('unlock');
-
-  // Create or login using our test user
-  if (isUnlockPage) {
-    // We're not starting from a fresh install, so login
-    await loginAsTestUser({ page, extensionId });
-  } else {
-    await registerTestUser({ page, extensionId });
-  }
-});
 
 setup('Import sender and receiver accounts', async ({ page, extensionId }) => {
   // Lock the extension and import sender and receiver accounts

--- a/e2e/utils/transaction.setup.ts
+++ b/e2e/utils/transaction.setup.ts
@@ -1,76 +1,8 @@
-import BN from 'bignumber.js';
-
-import {
-  importReceiverAccount,
-  importSenderAccount,
-  lockExtension,
-  expect,
-  switchToEvm,
-  loginToSenderAccount,
-} from './helper';
+import { importReceiverAccount, importSenderAccount, lockExtension } from './helper';
 import { test as setup } from './loader';
-
-// Define minimum required balances for each token
-const REQUIRED_BALANCES_CADENCE = {
-  flow: '0.01', // Sum of Flow transactions in Cadence (0.00123456 * 3) plus buffer
-  stFlow: '0.002', // stFlow requirement (0.00123456) plus buffer
-  'usdc.e': '0.002', // USDC requirement (0.00123456) plus buffer
-  beta: '0.002', // BETA requirement (0.00123456) plus buffer
-};
-
-const REQUIRED_BALANCES_EVM = {
-  flow: '0.15', // Sum of Flow transactions in EVM (0.12345678 + 0.00123456 * 2) plus buffer
-  stFlow: '0.000002', // stFlow requirement (0.00000112134354678) plus buffer
-  'usdc.e': '0.003', // Bridged USDC requirement (0.002468) plus buffer
-  beta: '0.002', // BETA requirement (0.001234567890123456) plus buffer
-};
-
-const getTokenBalance = async (page, tokenName: string): Promise<string> => {
-  await page.getByRole('tab', { name: 'coins' }).click();
-
-  // Get the balance from the token detail view
-  const balanceText = await page
-    .getByTestId(`coin-balance-${tokenName.toLowerCase()}`)
-    .textContent();
-
-  // Extract just the number from the balance text
-  const balance = balanceText?.match(/[\d.]+/)?.[0] || '0';
-  return balance;
-};
-
-const checkTokenBalance = (tokenName: string, actualBalance: string, requiredBalance: string) => {
-  const actual = new BN(actualBalance);
-  const required = new BN(requiredBalance);
-
-  expect(
-    actual.gte(required),
-    `Insufficient ${tokenName} balance. Required: ${requiredBalance}, Actual: ${actualBalance}`
-  ).toBeTruthy();
-};
 
 setup('Import sender and receiver accounts', async ({ page, extensionId }) => {
   // Lock the extension and import sender and receiver accounts
   await importSenderAccount({ page, extensionId });
-  await lockExtension({ page });
   await importReceiverAccount({ page, extensionId });
-});
-
-setup('Verify sufficient token balances for transaction tests', async ({ page, extensionId }) => {
-  // Login to sender account
-  await loginToSenderAccount({ page, extensionId });
-
-  // First check Cadence wallet balances
-  console.log('Checking Cadence wallet balances...');
-  for (const [tokenName, requiredBalance] of Object.entries(REQUIRED_BALANCES_CADENCE)) {
-    const balance = await getTokenBalance(page, tokenName);
-    checkTokenBalance(tokenName, balance, requiredBalance);
-  }
-
-  // Switch to EVM wallet and check balances
-  await switchToEvm({ page, extensionId: '' });
-  console.log('Checking EVM wallet balances...');
-  for (const [tokenName, requiredBalance] of Object.entries(REQUIRED_BALANCES_EVM)) {
-    const balance = await getTokenBalance(page, tokenName);
-    checkTokenBalance(tokenName, balance, requiredBalance);
-  }
 });

--- a/e2e/utils/transaction.teardown.ts
+++ b/e2e/utils/transaction.teardown.ts
@@ -1,10 +1,9 @@
 // Just import from playwright as we don't want to load the extension from the temp directory
 import { test as teardown } from '@playwright/test';
 
-import { cleanAuth, cleanExtension } from './helper';
+import { cleanExtension } from './loader';
 
-teardown('cleanup extension storage', async () => {
+teardown('cleanup extension data', async () => {
   //   Create a new page and navigate to extension
-  await cleanAuth();
   await cleanExtension();
 });

--- a/e2e/utils/transaction.teardown.ts
+++ b/e2e/utils/transaction.teardown.ts
@@ -5,5 +5,5 @@ import { cleanExtension } from './loader';
 
 teardown('cleanup extension data', async () => {
   //   Create a new page and navigate to extension
-  await cleanExtension();
+  await cleanExtension('transaction');
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,14 +23,14 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Use 2 workers for parallel execution. */
-  workers: 2,
+  workers: 4,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI ? 'github' : 'html',
   /* Stop after the first test failure */
   maxFailures: process.env.CI ? 1 : 0,
 
-  // set the timeout for each test to 60 seconds. We're sending transactions and waiting for them to be confirmed.
-  timeout: 60_000,
+  // set the timeout for each test to 90 seconds. We're sending transactions and waiting for them to be confirmed.
+  timeout: 90_000,
 
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,7 +17,7 @@ dotenv.config({ path: ['.env.dev', '.env.pro', '.env.test'] });
 export default defineConfig({
   testDir: './e2e',
   /* Run tests in files in parallel */
-  fullyParallel: false,
+  fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Use 2 workers for parallel execution. */
-  workers: 4,
+  workers: 2,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI ? 'github' : 'html',
   /* Stop after the first test failure */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,20 +17,20 @@ dotenv.config({ path: ['.env.dev', '.env.pro', '.env.test'] });
 export default defineConfig({
   testDir: './e2e',
   /* Run tests in files in parallel */
-  fullyParallel: true,
+  fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests because we are using a data directory. */
-  workers: 1,
+  /* Use 2 workers for parallel execution. */
+  workers: 2,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI ? 'github' : 'html',
   /* Stop after the first test failure */
   maxFailures: process.env.CI ? 1 : 0,
 
-  // set the timeout for each test to 120 seconds. We're sending transactions and waiting for them to be confirmed.
-  timeout: 120_000,
+  // set the timeout for each test to 60 seconds. We're sending transactions and waiting for them to be confirmed.
+  timeout: 60_000,
 
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
@@ -53,18 +53,42 @@ export default defineConfig({
   // timeout: 3_600_000,
   /* Configure projects for major browsers */
   projects: [
+    // registration
     {
-      name: 'setup',
-      testMatch: /.*global\.setup\.ts/,
-      teardown: 'cleanup',
+      name: 'registration-setup',
+      testMatch: /.*registration\.setup\.ts/,
+      teardown: 'registration-teardown',
+      fullyParallel: false,
     },
     {
-      name: 'main',
-      dependencies: ['setup'],
+      name: 'registration-test',
+      testMatch: /.*login\.test\.ts/,
+      dependencies: ['registration-setup'],
+      fullyParallel: false,
     },
     {
-      name: 'cleanup',
-      testMatch: /.*global\.teardown\.ts/,
+      name: 'registration-teardown',
+      testMatch: /.*registration\.teardown\.ts/,
+      fullyParallel: false,
+    },
+
+    // transaction
+    {
+      name: 'transaction-setup',
+      testMatch: /.*transaction\.setup\.ts/,
+      teardown: 'transaction-teardown',
+      fullyParallel: false,
+    },
+    {
+      name: 'transaction-test',
+      testMatch: /.*transaction\.test\.ts/,
+      dependencies: ['transaction-setup'],
+      fullyParallel: false,
+    },
+    {
+      name: 'transaction-teardown',
+      testMatch: /.*transaction\.teardown\.ts/,
+      fullyParallel: false,
     },
 
     /* Test against mobile viewports. */

--- a/src/background/controller/wallet.ts
+++ b/src/background/controller/wallet.ts
@@ -1622,6 +1622,7 @@ export class WalletController extends BaseController {
     this.clearNFTCollection();
     this.clearEvmNFTList();
     this.clearCoinList();
+    transactionService.clear();
 
     // If switching main wallet, refresh the EVM wallet
     if (key === null) {

--- a/src/background/service/transaction.ts
+++ b/src/background/service/transaction.ts
@@ -54,35 +54,8 @@ class Transaction {
     });
   };
 
-  clear = () => {
-    this.store = {
-      expiry: now.getTime(),
-      total: 0,
-      transactionItem: {
-        mainnet: [],
-        crescendo: [],
-        testnet: [],
-      },
-      pendingItem: {
-        mainnet: [],
-        testnet: [],
-        crescendo: [],
-      },
-    };
-    this.session = {
-      expiry: now.getTime(),
-      total: 0,
-      transactionItem: {
-        mainnet: [],
-        testnet: [],
-        crescendo: [],
-      },
-      pendingItem: {
-        mainnet: [],
-        testnet: [],
-        crescendo: [],
-      },
-    };
+  clear = async () => {
+    await this.init();
   };
 
   setPending = (txId: string, address: string, network, icon, title) => {

--- a/src/background/service/userWallet.ts
+++ b/src/background/service/userWallet.ts
@@ -1,5 +1,6 @@
 import * as secp from '@noble/secp256k1';
 import * as fcl from '@onflow/fcl';
+import type { Account as FclAccount } from '@onflow/typedefs';
 import { getApp } from 'firebase/app';
 import { getAuth, signInAnonymously } from 'firebase/auth/web-extension';
 
@@ -476,7 +477,7 @@ class UserWallet {
     return await this.sigInWithPk(privateKey);
   };
 
-  authorizationFunction = async (account: any = {}) => {
+  authorizationFunction = async (account: FclAccount) => {
     // authorization function need to return an account
     const address = fcl.withPrefix(await wallet.getMainAddress());
     const ADDRESS = fcl.withPrefix(address);


### PR DESCRIPTION
## Related Issue

Closes #728

## Summary of Changes

- Split up tests so that the registration and transcaction tests run in parallel
- Also runs the two sets of transaction tests in parallel
- One worker will send from sender to receiver, and the other from receiver to sender. This should minimize the chances of us running out of tokens in one account or the other
- Cadence transactions only wait until executed
- A test runs at the end to check they were all sealed and the amounts were correct
- Tests should now complete much faster

## Need Regression Testing

Doesn't affect core code. Just the automated tests

- [ ] Yes
- [X] No

## Risk Assessment

- [X] Low
- [ ] Medium
- [ ] High

