### PR TITLE
756 feature replace indexer endpoint in extension

### DIFF
--- a/src/background/service/openapi.ts
+++ b/src/background/service/openapi.ts
@@ -27,6 +27,7 @@ import {
   type ActiveChildType,
   type PublicKeyAccount,
   isEvmAccountType,
+  type KeyIndexerAccountResponse,
 } from '@/shared/types/wallet-types';
 import { isValidFlowAddress, isValidEthereumAddress } from '@/shared/utils/address';
 import { getStringFromHashAlgo, getStringFromSignAlgo } from '@/shared/utils/algo';
@@ -140,6 +141,11 @@ export interface OpenApiConfigValue {
 export interface OpenApiStore {
   host: string;
   config: Record<string, OpenApiConfigValue>;
+}
+
+interface KeyIndexerProfileResponse {
+  publicKey: string;
+  accounts: PublicKeyAccount[];
 }
 
 // TODO: Add SDKs for Firebase products that you want to use
@@ -2036,6 +2042,24 @@ class OpenApiService {
 
     log.log('otherAccounts with index:', otherAccounts);
     return { otherAccounts, wallet, loggedInAccounts };
+  };
+
+  getAccountsWithPublicKey = async (
+    publicKey: string,
+    network: string
+  ): Promise<PublicKeyAccount[]> => {
+    const url = await this.sendRequest(
+      'GET',
+      `/api/v4/key-indexer/${publicKey}`,
+      { network },
+      {},
+      WEB_NEXT_URL
+    );
+
+    const result = await fetch(url);
+    const json: KeyIndexerProfileResponse = await result.json();
+
+    return json.accounts;
   };
 
   /**

--- a/src/background/service/openapi.ts
+++ b/src/background/service/openapi.ts
@@ -27,7 +27,6 @@ import {
   type ActiveChildType,
   type PublicKeyAccount,
   isEvmAccountType,
-  type KeyIndexerAccountResponse,
 } from '@/shared/types/wallet-types';
 import { isValidFlowAddress, isValidEthereumAddress } from '@/shared/utils/address';
 import { getStringFromHashAlgo, getStringFromSignAlgo } from '@/shared/utils/algo';

--- a/src/background/service/openapi.ts
+++ b/src/background/service/openapi.ts
@@ -2048,7 +2048,7 @@ class OpenApiService {
     publicKey: string,
     network: string
   ): Promise<PublicKeyAccount[]> => {
-    const url = await this.sendRequest(
+    const result: PublicKeyAccount[] = await this.sendRequest(
       'GET',
       `/api/v4/key-indexer/${publicKey}`,
       { network },
@@ -2056,10 +2056,7 @@ class OpenApiService {
       WEB_NEXT_URL
     );
 
-    const result = await fetch(url);
-    const json: KeyIndexerProfileResponse = await result.json();
-
-    return json.accounts;
+    return result;
   };
 
   /**

--- a/src/background/service/openapi.ts
+++ b/src/background/service/openapi.ts
@@ -143,7 +143,7 @@ export interface OpenApiStore {
   config: Record<string, OpenApiConfigValue>;
 }
 
-interface KeyIndexerProfileResponse {
+export interface KeyIndexerProfileResponse {
   publicKey: string;
   accounts: PublicKeyAccount[];
 }

--- a/src/background/service/openapi.ts
+++ b/src/background/service/openapi.ts
@@ -142,11 +142,6 @@ export interface OpenApiStore {
   config: Record<string, OpenApiConfigValue>;
 }
 
-export interface KeyIndexerProfileResponse {
-  publicKey: string;
-  accounts: PublicKeyAccount[];
-}
-
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
 

--- a/src/background/service/userWallet.ts
+++ b/src/background/service/userWallet.ts
@@ -217,6 +217,11 @@ class UserWallet {
     };
   };
 
+  getAccountsWithPublicKey = async (publicKey: string, network: string) => {
+    const accounts = await openapiService.getAccountsWithPublicKey(publicKey, network);
+    return accounts;
+  };
+
   setChildAccounts = async (
     childAccountMap: ChildAccountMap,
     address: FlowAddress,

--- a/src/background/service/userWallet.ts
+++ b/src/background/service/userWallet.ts
@@ -217,7 +217,10 @@ class UserWallet {
     };
   };
 
-  getAccountsWithPublicKey = async (publicKey: string, network: string) => {
+  getAccountsWithPublicKey = async (
+    publicKey: string,
+    network: string
+  ): Promise<PublicKeyAccount[]> => {
     const accounts = await openapiService.getAccountsWithPublicKey(publicKey, network);
     return accounts;
   };

--- a/src/background/utils/modules/findAddressWithPubKey.ts
+++ b/src/background/utils/modules/findAddressWithPubKey.ts
@@ -42,21 +42,6 @@ export const getAccountsByPublicKeyTuple = async (
   return accounts;
 };
 
-type KeyIndexerAccountResponse = {
-  address: string;
-  keyId: number;
-  weight: number;
-  sigAlgo: number;
-  hashAlgo: number;
-  signing: SignAlgoString;
-  hashing: HashAlgoString;
-};
-
-type KeyIndexerProfileResponse = {
-  publicKey: string;
-  accounts: KeyIndexerAccountResponse[];
-};
-
 /*
  * Connect to the indexer to get all accounts associated with a public key
  * This is used to get the accounts for the current user

--- a/src/background/utils/modules/findAddressWithPubKey.ts
+++ b/src/background/utils/modules/findAddressWithPubKey.ts
@@ -69,26 +69,7 @@ async function getAccountsWithPublicKey(
   publicKey: string,
   network: string
 ): Promise<PublicKeyAccount[]> {
-  const url =
-    network === 'testnet'
-      ? `https://staging.key-indexer.flow.com/key/${publicKey}`
-      : `https://production.key-indexer.flow.com/key/${publicKey}`;
-  const result = await fetch(url);
-  const json: KeyIndexerProfileResponse = await result.json();
-
-  // Now massage the data to match the type we want
-  const accounts: PublicKeyAccount[] = json.accounts.map((account) => ({
-    address: account.address,
-    publicKey: json.publicKey,
-    keyIndex: account.keyId,
-    weight: account.weight,
-    signAlgo: account.sigAlgo,
-    signAlgoString: account.signing,
-    hashAlgo: account.hashAlgo,
-    hashAlgoString: account.hashing,
-  }));
-
-  return accounts;
+  return userWalletService.getAccountsWithPublicKey(publicKey, network);
 }
 
 const getPublicKeyInfoForAccount = async (

--- a/src/shared/test-data/test-groups.ts
+++ b/src/shared/test-data/test-groups.ts
@@ -93,6 +93,10 @@ export const createTestGroups = (commonParams: CommonParams): ApiTestGroups => {
       { name: 'userInfo', params: {} },
       { name: 'searchUser', params: { keyword: 'webdev18_862' } },
       { name: 'checkImport', params: { key: 'test' } },
+      {
+        name: 'getAccountsWithPublicKey',
+        params: { publicKey: commonParams.publicKey.P256.pubK, network: commonParams.network },
+      },
     ],
     wallet: [{ name: 'createFlowAddress', params: {} }],
     device: [

--- a/src/shared/types/wallet-types.ts
+++ b/src/shared/types/wallet-types.ts
@@ -117,13 +117,3 @@ export type AccountDetails = {
 export type ChildAccountMap = {
   [key: string]: AccountDetails;
 };
-
-export type KeyIndexerAccountResponse = {
-  address: string;
-  keyId: number;
-  weight: number;
-  sigAlgo: number;
-  hashAlgo: number;
-  signing: SignAlgoString;
-  hashing: HashAlgoString;
-};

--- a/src/shared/types/wallet-types.ts
+++ b/src/shared/types/wallet-types.ts
@@ -117,3 +117,13 @@ export type AccountDetails = {
 export type ChildAccountMap = {
   [key: string]: AccountDetails;
 };
+
+export type KeyIndexerAccountResponse = {
+  address: string;
+  keyId: number;
+  weight: number;
+  sigAlgo: number;
+  hashAlgo: number;
+  signing: SignAlgoString;
+  hashing: HashAlgoString;
+};

--- a/src/ui/views/api-test/openapi-methods.json
+++ b/src/ui/views/api-test/openapi-methods.json
@@ -1056,5 +1056,14 @@
     "usesFetchDirectly": false,
     "basicSignature": "async getUserTokens(address: string, network?: string)",
     "params": ["address", "network"]
+  },
+  {
+    "name": "getAccountsWithPublicKey",
+    "isAsync": true,
+    "fullBody": "async (publicKey: string, network: string) => {\n    const accounts = await userWalletService.getAccountsWithPublicKey(publicKey, network);\n    return accounts;\n  }",
+    "usesSendRequest": true,
+    "usesFetchDirectly": false,
+    "basicSignature": "async (publicKey: string, network: string)",
+    "params": ["publicKey", "network"]
   }
 ]


### PR DESCRIPTION
## Related Issue

Closes #756 

Use new public key indexer endpoint in web-next api server

## Summary of Changes

instead of calling key-indexer directly go through api server

## Need Regression Testing

- [ ] Yes
- [x] No

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

