### PR TITLE
781 update create address

### DIFF
--- a/src/background/controller/wallet.ts
+++ b/src/background/controller/wallet.ts
@@ -231,7 +231,8 @@ export class WalletController extends BaseController {
     await this.createKeyringWithMnemonics(password, mnemonic);
     // We're creating the Flow address for the account
     // Only after this, do we have a valid wallet with a Flow address
-    await openapiService.createFlowAddress();
+    const result = await openapiService.createFlowAddressV2();
+    console.log('createFlowAddressV2 result', result);
 
     // Finally set the current pubkey in userWallet
     userWalletService.setCurrentPubkey(accountKey.public_key);

--- a/src/background/service/openapi.ts
+++ b/src/background/service/openapi.ts
@@ -251,6 +251,11 @@ const dataConfig: Record<string, OpenApiConfigValue> = {
     method: 'post',
     params: [],
   },
+  create_flow_address_v2: {
+    path: '/v2/user/address',
+    method: 'post',
+    params: [],
+  },
   loginv3: {
     path: '/v3/login',
     method: 'post',
@@ -911,6 +916,12 @@ class OpenApiService {
 
   createFlowAddress = async () => {
     const config = this.store.config.create_flow_address;
+    const data = await this.sendRequest(config.method, config.path);
+    return data;
+  };
+
+  createFlowAddressV2 = async () => {
+    const config = this.store.config.create_flow_address_v2;
     const data = await this.sendRequest(config.method, config.path);
     return data;
   };

--- a/src/background/service/userWallet.ts
+++ b/src/background/service/userWallet.ts
@@ -1168,7 +1168,6 @@ const setupNewAccount = async (
   account: FclAccount
 ): Promise<MainAccount[]> => {
   // Setup new account after
-  console.log('setupNewAccount', account);
   const mainAccounts: MainAccount[] = [
     {
       keyIndex: account.keys[0].index,
@@ -1210,7 +1209,6 @@ const loadMainAccountsWithPubKey = async (
 ): Promise<MainAccount[]> => {
   // Check if cache is still valid first
   const existing = await getValidData<MainAccount[]>(mainAccountsKey(network, pubKey));
-  console.log('loadMainAccountsWithPubKey', existing);
   if (existing !== undefined) {
     return existing;
   }

--- a/src/background/service/userWallet.ts
+++ b/src/background/service/userWallet.ts
@@ -1,5 +1,6 @@
 import * as secp from '@noble/secp256k1';
 import * as fcl from '@onflow/fcl';
+import type { Account as FclAccount } from '@onflow/typedefs';
 import * as ethUtil from 'ethereumjs-util';
 import { getApp } from 'firebase/app';
 import { getAuth, signInAnonymously } from 'firebase/auth/web-extension';
@@ -30,7 +31,7 @@ import {
   getActiveAccountTypeForAddress,
   type WalletAddress,
 } from '@/shared/types/wallet-types';
-import { ensureEvmAddressPrefix, isValidEthereumAddress } from '@/shared/utils/address';
+import { ensureEvmAddressPrefix, isValidEthereumAddress, withPrefix } from '@/shared/utils/address';
 import {
   FLOW_BIP44_PATH,
   HASH_ALGO_NUM_SHA2_256,
@@ -151,6 +152,25 @@ class UserWallet {
     // It stores the value in memory immediately
     // However the value in storage may not be updated immediately
     this.store.currentPubkey = pubkey;
+
+    // Load all data for the new pubkey. This is async but don't await it
+    this.loadAllAccounts(this.store.network, pubkey);
+  };
+
+  /**
+   * Set the current pubkey in registered state
+   * TODO: There are lots of async methods "get" the current pubkey before performing an action
+   * Switching the pubkey mid action may cause unexpected behavior
+   * It would be better practice to either pass the pubkey to actions or have class instances
+   * for each pubkey and network combination
+   * @param pubkey - The pubkey to set
+   */
+  registerCurrentPubkey = async (pubkey: string, account: FclAccount) => {
+    // Note that values that are set in the proxy store are immediately available through the proxy
+    // It stores the value in memory immediately
+    // However the value in storage may not be updated immediately
+    this.store.currentPubkey = pubkey;
+    await setupNewAccount(this.store.network, pubkey, account);
 
     // Load all data for the new pubkey. This is async but don't await it
     this.loadAllAccounts(this.store.network, pubkey);
@@ -1135,6 +1155,49 @@ const loadAllAccountsWithPubKey = async (network: string, pubKey: string) => {
 };
 
 /**
+ * Setup the main accounts for a given public key after registration is complete
+ * Store in the data cache
+ * @param network - The network to load the accounts for
+ * @param pubKey - The public key to load the accounts for
+ * @param account - The account structure getting from fcl after registration is complete
+ * @returns The main accounts for the given public key or null if not found. Does not throw an error.
+ */
+const setupNewAccount = async (
+  network: string,
+  pubKey: string,
+  account: FclAccount
+): Promise<MainAccount[]> => {
+  // Setup new account after
+  console.log('setupNewAccount', account);
+  const mainAccounts: MainAccount[] = [
+    {
+      keyIndex: account.keys[0].index,
+      weight: account.keys[0].weight,
+      signAlgo: account.keys[0].signAlgo,
+      signAlgoString: account.keys[0].signAlgoString,
+      hashAlgo: account.keys[0].hashAlgo,
+      hashAlgoString: account.keys[0].hashAlgoString,
+      address: withPrefix(account.address) as string,
+      publicKey: account.keys[0].publicKey,
+      chain: networkToChainId(network),
+      id: 0,
+      name: getEmojiByIndex(0).name,
+      icon: getEmojiByIndex(0).emoji,
+      color: getEmojiByIndex(0).bgcolor,
+    },
+  ];
+
+  // Save the main accounts to the cache
+  setCachedData(
+    mainAccountsKey(network, pubKey),
+    mainAccounts,
+    mainAccounts.length > 0 ? 60_000 : 1_000
+  );
+
+  return mainAccounts;
+};
+
+/**
  * Load the main accounts for a given public key
  * Store in the data cache
  * @param network - The network to load the accounts for
@@ -1147,6 +1210,7 @@ const loadMainAccountsWithPubKey = async (
 ): Promise<MainAccount[]> => {
   // Check if cache is still valid first
   const existing = await getValidData<MainAccount[]>(mainAccountsKey(network, pubKey));
+  console.log('loadMainAccountsWithPubKey', existing);
   if (existing !== undefined) {
     return existing;
   }


### PR DESCRIPTION
## Related Issue

Closes #781 
78
<!-- If this PR addresses an issue, link it here  -->

## Summary of Changes

Change the process of loading address after account creation. Now it call for a v2 API that returns the mainnet transaction id for the extension to update actively in the background.


Production API not yet applied to server.
## Need Regression Testing

<!-- Indicate whether this PR requires regression testing and why. -->

- [x] Yes
- [ ] No

## Risk Assessment

<!-- Assess the risk level of this PR:
- Low: Minimal impact, straightforward changes.
- Medium: Potential for some edge cases or indirect effects.
- High: Could affect critical functionality or many users.
-->

- [ ] Low
- [x] Medium
- [ ] High

## Additional Notes

<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)

<!-- Attach any screenshots that help explain your changes -->
