### PR TITLE
increase max width to allow longer token names

### DIFF
--- a/src/ui/views/Wallet/Coinlist.tsx
+++ b/src/ui/views/Wallet/Coinlist.tsx
@@ -93,7 +93,7 @@ const CoinList = ({
                 fontWeight: '550',
                 textAlign: 'start',
                 color: 'text.title',
-                maxWidth: '120px',
+                maxWidth: '160px',
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
                 whiteSpace: 'nowrap',


### PR DESCRIPTION
Closes #767

## Related Issue

Closes #<issue-number>

Increased allowable width before ellipse takes over and truncates the token name

## Summary of Changes

![Screenshot 2025-04-10 at 15 43 15](https://github.com/user-attachments/assets/2196c2e8-d731-48a4-9bbf-25c1aa3dabeb)



## Need Regression Testing

- [ ] Yes
- [x] No

## Risk Assessment

<!-- Assess the risk level of this PR:
- Low: Minimal impact, straightforward changes.
- Medium: Potential for some edge cases or indirect effects.
- High: Could affect critical functionality or many users.
-->

- [x] Low
- [ ] Medium
- [ ] High


