### PR TITLE
fix summing token balance when price doesnt exist

### DIFF
--- a/src/ui/hooks/useCoinHook.ts
+++ b/src/ui/hooks/useCoinHook.ts
@@ -52,7 +52,7 @@ export const useCoins = () => {
       for (const coin of data) {
         // Calculate sum and flow balance
         if (coin.total !== null) {
-          sum = sum.plus(new BN(coin.total));
+          sum = sum.plus(new BN(coin?.total || 0));
           if (coin.unit && coin.unit.toLowerCase() === 'flow') {
             flowBalance = new BN(coin.balance);
           }
@@ -63,7 +63,7 @@ export const useCoins = () => {
       await Promise.all([
         setTotalFlow(flowBalance.toString()),
         setAvailableFlow(flowBalance.toString()),
-        setBalance(`$ ${sum.toFixed(2)}`),
+        setBalance(sum.toString()),
       ]);
     },
     [setTotalFlow, setBalance]


### PR DESCRIPTION
Closes #852

## Related Issue


## Summary of Changes

update summing function to default to 0 if token doesn't not have a price

## Need Regression Testing

<!-- Indicate whether this PR requires regression testing and why. -->

- [x] Yes
- [ ] No

## Risk Assessment


- [x] Low
- [ ] Medium
- [ ] High


Now showing portfolio value even with priceless token 

![Screenshot 2025-04-23 at 17 42 42](https://github.com/user-attachments/assets/a0092e86-b3a9-4d43-b920-9dec38a0e065)


