### PR TITLE
856-feature-correct-data-accessors-in-userwallet

### DIFF
--- a/build/prepareManifest.ts
+++ b/build/prepareManifest.ts
@@ -68,6 +68,7 @@ async function prepare() {
 
   if (mode === 'dev') {
     manifest.key = process.env.MANIFEST_KEY;
+    manifest.name = 'Flow Wallet Dev';
     try {
       const devToolsScript = await fetchDevTools();
       fs.writeFileSync(path.resolve(__dirname, '../_raw/react-devtools.js'), devToolsScript);

--- a/e2e/utils/helper.ts
+++ b/e2e/utils/helper.ts
@@ -288,7 +288,6 @@ export const importAccountBySeedPhrase = async ({
   await page.goto(`chrome-extension://${extensionId}/index.html#/dashboard`);
   await page.waitForURL(/.*\/dashboard.*/);
   // Wait for the account address to be visible
-  await expect(page.getByText(accountAddr)).toBeVisible({ timeout: 10_000 });
   const flowAddr = await getCurrentAddress(page);
 
   if (accountAddr && flowAddr !== accountAddr) {

--- a/src/background/controller/wallet.ts
+++ b/src/background/controller/wallet.ts
@@ -442,7 +442,7 @@ export class WalletController extends BaseController {
     // Try for 2 mins to get the parent address
     const parentAddress = await retryOperation(
       async () => {
-        const address = userWalletService.getParentAddress();
+        const address = await userWalletService.getParentAddress();
         console.log('retryOperation - refreshWallets - parentAddress', address);
         if (!address) {
           throw new Error('Parent address not found');
@@ -1254,8 +1254,8 @@ export class WalletController extends BaseController {
     return wallets;
   };
 
-  getActiveAccountType = (): ActiveAccountType => {
-    const activeWallet = userWalletService.getActiveAccountType();
+  getActiveAccountType = async (): Promise<ActiveAccountType> => {
+    const activeWallet = await userWalletService.getActiveAccountType();
     return activeWallet;
   };
 
@@ -3327,9 +3327,7 @@ export class WalletController extends BaseController {
   };
 
   allowLilicoPay = async (): Promise<boolean> => {
-    const isFreeGasFeeKillSwitch = await storage.get('freeGas');
-    const isFreeGasFeeEnabled = await storage.get('lilicoPayer');
-    return isFreeGasFeeKillSwitch && isFreeGasFeeEnabled;
+    return userWalletService.allowFreeGas();
   };
 
   signPayer = async (signable): Promise<string> => {
@@ -3415,7 +3413,7 @@ export class WalletController extends BaseController {
     movingBetweenEVMAndFlow?: boolean; // are we moving between EVM and Flow?
   } = {}): Promise<EvaluateStorageResult> => {
     const address = await this.getParentAddress();
-    const isFreeGasFeeEnabled = await this.allowLilicoPay();
+    const isFreeGasFeeEnabled = await userWalletService.allowFreeGas();
     const result = await this.storageEvaluator.evaluateStorage(
       address!,
       transferAmount,

--- a/src/background/service/conditions-evaluator.ts
+++ b/src/background/service/conditions-evaluator.ts
@@ -30,12 +30,12 @@ class ConditionsEvaluator {
         }
 
       case 'insufficientStorage': {
-        const currentAddress = userWalletService.getCurrentAddress();
+        const currentAddress = await userWalletService.getCurrentAddress();
         if (!currentAddress) return false;
         return this.evaluateStorageCondition(currentAddress);
       }
       case 'insufficientBalance': {
-        const currentAddress = userWalletService.getCurrentAddress();
+        const currentAddress = await userWalletService.getCurrentAddress();
         if (!currentAddress) return false;
         return this.evaluateBalanceCondition(currentAddress);
       }

--- a/src/background/service/user.ts
+++ b/src/background/service/user.ts
@@ -54,7 +54,6 @@ class UserInfoService {
     });
   };
   loadUserInfoByUserId = async (userId: string) => {
-    console.trace('loadUserInfoByUserId', userId);
     const currentId = await returnCurrentProfileId();
 
     const userInfo: UserInfoResponse | undefined =

--- a/src/background/service/userWallet.ts
+++ b/src/background/service/userWallet.ts
@@ -88,7 +88,7 @@ class UserWallet {
   private store!: UserWalletStore;
 
   // Reference to the wallet controller
-  private walletController: WalletController | undefined;
+  private walletController: WalletController | undefined = undefined;
 
   setWalletController = (controller: WalletController) => {
     this.walletController = controller;

--- a/src/background/service/userWallet.ts
+++ b/src/background/service/userWallet.ts
@@ -332,13 +332,16 @@ class UserWallet {
       validatedActiveAccounts.parentAddress !== activeAccounts?.parentAddress ||
       validatedActiveAccounts.currentAddress !== activeAccounts?.currentAddress
     ) {
-      this.activeAccounts[network][pubkey] = validatedActiveAccounts;
-
       await setUserData<ActiveAccountsStore>(
         activeAccountsKey(network, pubkey),
         validatedActiveAccounts
       );
     }
+    if (!this.activeAccounts[network]) {
+      this.activeAccounts[network] = new Map();
+    }
+    this.activeAccounts[network][pubkey] = validatedActiveAccounts;
+
     return validatedActiveAccounts;
   };
 

--- a/src/background/utils/remoteConfig.ts
+++ b/src/background/utils/remoteConfig.ts
@@ -1,16 +1,10 @@
 import { storage } from '@/background/webapi';
 import { type NFTModelV2 } from '@/shared/types/network-types';
 
-import { userWalletService } from '../service';
 import openapi from '../service/openapi';
 
 import defaultConfig from './defaultConfig.json';
-import defaultNftListMainnet from './defaultNftList.mainnet.json';
-import defaultNftListTestnet from './defaultNftList.testnet.json';
 import defaultTokenList from './defaultTokenList.json';
-
-const { tokens: mainnetNftList } = defaultNftListMainnet;
-const { tokens: testnetNftList } = defaultNftListTestnet;
 
 interface CacheState {
   result: any;


### PR DESCRIPTION
## Related Issue

Closes #856

## Summary of Changes

Created accessors as per the data cache model background pattern. In the background, accessors must call loaders to expliticly load data if not yet loaded. eg. getMainAccounts must call loadMainAcconts if the cache data is invalid. This is appropriate behaviour for background only accessors

## Need Regression Testing

Changes code in userWallet around how data is loaded.

- [X] Yes
- [ ] No

## Risk Assessment

Changes core code in userWallet to explitly load data if not cached

- [ ] Low
- [X] Medium
- [ ] High
