### PR TITLE
add balancePath from backend to populate token.path.balance

### DIFF
--- a/src/background/service/openapi.ts
+++ b/src/background/service/openapi.ts
@@ -107,6 +107,10 @@ interface FlowTokenResponse {
     domain: string;
     identifier: string;
   };
+  balancePath: {
+    domain: string;
+    identifier: string;
+  };
   identifier: string;
   isVerified: boolean;
   priceInUSD: string;
@@ -2309,7 +2313,9 @@ class OpenApiService {
           receiver: token.receiverPath
             ? `/${token.receiverPath.domain}/${token.receiverPath.identifier}`
             : '', // Provide a default value if receiverPath is null
-          balance: ``, // todo: not sure what this property is used for
+          balance: token.balancePath
+            ? `/${token.balancePath.domain}/${token.balancePath.identifier}`
+            : '', // Provide a default value if balancePath is null
         },
         logoURI: token.logoURI || token.logos?.items?.[0]?.file?.url || '',
         extensions: {


### PR DESCRIPTION
Closes #871

## Summary of Changes


This pull request updates the `FlowTokenResponse` interface and the `OpenApiService` class to handle a new `balancePath` property, ensuring consistent data handling for token balance paths.

### Enhancements to `FlowTokenResponse` interface:
* Added a new `balancePath` property to the `FlowTokenResponse` interface, which includes `domain` and `identifier` fields. (`src/background/service/openapi.ts`, [src/background/service/openapi.tsR110-R113](diffhunk://#diff-c2ea9ca0d354826bc742869c6c8bfba25f9376b361843f698a0109c84ad7aed1R110-R113))

### Updates to `OpenApiService` class:
* Updated the `balance` property in the `OpenApiService` class to dynamically construct a path using the new `balancePath` property, with a fallback to an empty string if `balancePath` is null. (`src/background/service/openapi.ts`, [src/background/service/openapi.tsL2312-R2318](diffhunk://#diff-c2ea9ca0d354826bc742869c6c8bfba25f9376b361843f698a0109c84ad7aed1L2312-R2318))

## Need Regression Testing

<!-- Indicate whether this PR requires regression testing and why. -->

- [ ] Yes
- [x] No

## Risk Assessment

<!-- Assess the risk level of this PR:
- Low: Minimal impact, straightforward changes.
- Medium: Potential for some edge cases or indirect effects.
- High: Could affect critical functionality or many users.
-->

- [x] Low
- [ ] Medium
- [ ] High


