### PR TITLE
style to show long token names, move move button

### DIFF
--- a/src/ui/views/TokenDetail/TokenInfoCard.tsx
+++ b/src/ui/views/TokenDetail/TokenInfoCard.tsx
@@ -1,5 +1,5 @@
-import { Typography, Box, ButtonBase, CardMedia, Skeleton } from '@mui/material';
-import React, { useEffect, useState, useRef, useCallback, useMemo } from 'react';
+import { Typography, Box, ButtonBase, Skeleton } from '@mui/material';
+import React, { useMemo } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { type CoinItem, type ExtendedTokenInfo } from '@/shared/types/coin-types';
@@ -9,12 +9,10 @@ import buyIcon from '@/ui/FRWAssets/svg/buyIcon.svg';
 import receiveIcon from '@/ui/FRWAssets/svg/receiveIcon.svg';
 import sendIcon from '@/ui/FRWAssets/svg/sendIcon.svg';
 import swapIcon from '@/ui/FRWAssets/svg/swapIcon.svg';
-import { LLPrimaryButton } from '@/ui/FRWComponent';
 import { IconButton } from '@/ui/FRWComponent/IconButton';
 import { useProfiles } from '@/ui/hooks/useProfileHook';
 import iconMove from 'ui/FRWAssets/svg/move.svg';
 import { useCoins } from 'ui/hooks/useCoinHook';
-import { useWallet } from 'ui/utils';
 
 import IconChevronRight from '../../../components/iconfont/IconChevronRight';
 import VerifiedIcon from '../../FRWAssets/svg/verfied-check.svg';
@@ -24,19 +22,11 @@ import { CurrencyValue } from './CurrencyValue';
 // import tips from 'ui/FRWAssets/svg/tips.svg';
 
 const TokenInfoCard = ({
-  price,
-  token,
-  setAccessible,
-  accessible,
   tokenInfo,
   accountType,
   tokenId,
   setIsOnRamp,
 }: {
-  price: string;
-  token: string;
-  setAccessible: (accessible: boolean) => void;
-  accessible: boolean;
   tokenInfo: CoinItem | undefined;
   accountType: ActiveAccountType;
   tokenId: string;
@@ -79,20 +69,20 @@ const TokenInfoCard = ({
         alignItems: 'start',
         px: '11px',
         pb: '30px',
-        mt: '12px',
+        mt: '0px',
         minHeight: '230px',
         borderRadius: '12px',
       }}
     >
       <>
-        <Box sx={{ mt: '-12px', display: 'flex', justifyContent: 'space-between', width: '100%' }}>
+        <Box sx={{ width: '100%', display: 'flex', alignItems: 'center' }}>
           {extendedTokenInfo?.logoURI ? (
             <img
               style={{
-                height: '64px',
-                width: '64px',
+                height: '42px',
+                width: '42px',
                 backgroundColor: '#282828',
-                borderRadius: '32px',
+                borderRadius: '21px',
               }}
               src={
                 extendedTokenInfo.logoURI ||
@@ -100,11 +90,12 @@ const TokenInfoCard = ({
               }
             ></img>
           ) : (
-            <Skeleton variant="circular" width={64} height={64} />
+            <Skeleton variant="circular" width={42} height={42} />
           )}
-          <Box sx={{ display: 'flex', alignItems: 'end' }}>
+          <Box sx={{ display: 'flex', flex: 1, ml: 2 }}>
             <ButtonBase
               onClick={() => extendedTokenInfo && window.open(getUrl(extendedTokenInfo), '_blank')}
+              sx={{ width: '100%' }}
             >
               <Box
                 sx={{
@@ -115,19 +106,17 @@ const TokenInfoCard = ({
                   py: '4px',
                   marginRight: '2px',
                   borderRadius: '8px',
-                  alignSelf: 'end',
+                  width: '100%',
+                  minHeight: '42px',
                   background: 'linear-gradient(to right, #000000, #282828)',
                 }}
               >
-                <>
+                <Box sx={{ flex: 1, display: 'flex', alignItems: 'center', gap: 1 }}>
                   <Typography
                     variant="h6"
                     sx={{
                       fontWeight: '550',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                      maxWidth: '90px',
+                      wordBreak: 'break-word',
                     }}
                   >
                     {extendedTokenInfo ? (
@@ -136,54 +125,18 @@ const TokenInfoCard = ({
                       <Skeleton variant="text" width={90} />
                     )}
                   </Typography>
-                </>
-                <IconChevronRight size={20} />
-              </Box>
-            </ButtonBase>
-            {extendedTokenInfo?.isVerified && (
-              <Box
-                sx={{ display: 'flex', alignItems: 'center', height: '40px', marginRight: '4px' }}
-              >
-                <img src={VerifiedIcon} alt="Verified" style={{ width: '24px', height: '24px' }} />
-              </Box>
-            )}
-          </Box>
-
-          <Box sx={{ flex: 1 }} />
-          {canMoveToChild && balance && (
-            <ButtonBase onClick={() => toSend()}>
-              <Box sx={{ display: 'flex', alignItems: 'center', height: '46px' }}>
-                <Box
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    background: 'rgba(65, 204, 93, 0.16)',
-                    gap: '4px',
-                    px: '8px',
-                    // py: '4px',
-                    height: '24px',
-                    borderRadius: '8px',
-                    alignSelf: 'end',
-                  }}
-                >
-                  <Typography sx={{ fontWeight: '400', fontSize: '12px', color: '#41CC5D' }}>
-                    {chrome.i18n.getMessage('Move')}
-                  </Typography>
-                  <img
-                    src={iconMove}
-                    alt="Move Icon"
-                    style={{
-                      width: '14px',
-                      height: '14px',
-                      marginLeft: '4px',
-                      filter:
-                        'invert(54%) sepia(78%) saturate(366%) hue-rotate(85deg) brightness(95%) contrast(92%)',
-                    }}
-                  />
+                  {extendedTokenInfo?.isVerified && (
+                    <img
+                      src={VerifiedIcon}
+                      alt="Verified"
+                      style={{ width: '20px', height: '20px' }}
+                    />
+                  )}
                 </Box>
+                <IconChevronRight size={20} sx={{ flexShrink: 0 }} />
               </Box>
             </ButtonBase>
-          )}
+          </Box>
         </Box>
         <Box
           sx={{
@@ -192,32 +145,70 @@ const TokenInfoCard = ({
             gap: '6px',
             pt: '18px',
             width: '100%',
+            justifyContent: 'space-between',
           }}
         >
-          <Typography
-            variant="body1"
-            sx={{
-              fontWeight: '700',
-              fontSize: 'clamp(16px, 5vw, 32px)',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-            }}
-          >
-            {balance !== undefined ? balance : <Skeleton variant="text" width={100} />}
-          </Typography>
-          <Typography
-            variant="caption"
-            color="neutral2.main"
-            sx={{
-              fontWeight: 'medium',
-              fontSize: '14px',
-              textTransform: 'uppercase',
-              flexShrink: 0,
-            }}
-          >
-            {extendedTokenInfo ? extendedTokenInfo?.symbol : <Skeleton variant="text" width={50} />}
-          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'baseline', gap: '6px' }}>
+            <Typography
+              variant="body1"
+              sx={{
+                fontWeight: '700',
+                fontSize: 'clamp(16px, 5vw, 32px)',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {balance !== undefined ? balance : <Skeleton variant="text" width={100} />}
+            </Typography>
+            <Typography
+              variant="caption"
+              color="neutral2.main"
+              sx={{
+                fontWeight: 'medium',
+                fontSize: '14px',
+                textTransform: 'uppercase',
+                flexShrink: 0,
+              }}
+            >
+              {extendedTokenInfo ? (
+                extendedTokenInfo?.symbol
+              ) : (
+                <Skeleton variant="text" width={50} />
+              )}
+            </Typography>
+          </Box>
+          {canMoveToChild && balance && (
+            <ButtonBase onClick={() => toSend()}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  background: 'rgba(65, 204, 93, 0.16)',
+                  gap: '4px',
+                  px: '8px',
+                  height: '24px',
+                  borderRadius: '8px',
+                  alignSelf: 'center',
+                }}
+              >
+                <Typography sx={{ fontWeight: '400', fontSize: '12px', color: '#41CC5D' }}>
+                  {chrome.i18n.getMessage('Move')}
+                </Typography>
+                <img
+                  src={iconMove}
+                  alt="Move Icon"
+                  style={{
+                    width: '14px',
+                    height: '14px',
+                    marginLeft: '4px',
+                    filter:
+                      'invert(54%) sepia(78%) saturate(366%) hue-rotate(85deg) brightness(95%) contrast(92%)',
+                  }}
+                />
+              </Box>
+            </ButtonBase>
+          )}
         </Box>
         <Typography variant="body1" color="text.secondary" sx={{ fontSize: '16px' }}>
           <Box component="span" sx={{ marginRight: '0.25rem' }}>

--- a/src/ui/views/TokenDetail/TokenInfoCard.tsx
+++ b/src/ui/views/TokenDetail/TokenInfoCard.tsx
@@ -99,7 +99,7 @@ const TokenInfoCard = ({
                     height: '16px',
                     position: 'absolute',
                     bottom: '4px',
-                    right: '-4px',
+                    right: '-14px',
                     zIndex: 1,
                   }}
                 />

--- a/src/ui/views/TokenDetail/TokenInfoCard.tsx
+++ b/src/ui/views/TokenDetail/TokenInfoCard.tsx
@@ -77,18 +77,34 @@ const TokenInfoCard = ({
       <>
         <Box sx={{ width: '100%', display: 'flex', alignItems: 'center' }}>
           {extendedTokenInfo?.logoURI ? (
-            <img
-              style={{
-                height: '42px',
-                width: '42px',
-                backgroundColor: '#282828',
-                borderRadius: '21px',
-              }}
-              src={
-                extendedTokenInfo.logoURI ||
-                'https://cdn.jsdelivr.net/gh/FlowFans/flow-token-list@main/token-registry/A.1654653399040a61.FlowToken/logo.svg'
-              }
-            ></img>
+            <Box sx={{ position: 'relative' }}>
+              <img
+                style={{
+                  height: '42px',
+                  width: '42px',
+                  backgroundColor: '#282828',
+                  borderRadius: '21px',
+                }}
+                src={
+                  extendedTokenInfo.logoURI ||
+                  'https://cdn.jsdelivr.net/gh/FlowFans/flow-token-list@main/token-registry/A.1654653399040a61.FlowToken/logo.svg'
+                }
+              />
+              {extendedTokenInfo?.isVerified && (
+                <img
+                  src={VerifiedIcon}
+                  alt="Verified"
+                  style={{
+                    width: '16px',
+                    height: '16px',
+                    position: 'absolute',
+                    bottom: '4px',
+                    right: '-4px',
+                    zIndex: 1,
+                  }}
+                />
+              )}
+            </Box>
           ) : (
             <Skeleton variant="circular" width={42} height={42} />
           )}
@@ -111,7 +127,7 @@ const TokenInfoCard = ({
                   background: 'linear-gradient(to right, #000000, #282828)',
                 }}
               >
-                <Box sx={{ flex: 1, display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Box sx={{ flex: 1 }}>
                   <Typography
                     variant="h6"
                     sx={{
@@ -125,13 +141,6 @@ const TokenInfoCard = ({
                       <Skeleton variant="text" width={90} />
                     )}
                   </Typography>
-                  {extendedTokenInfo?.isVerified && (
-                    <img
-                      src={VerifiedIcon}
-                      alt="Verified"
-                      style={{ width: '20px', height: '20px' }}
-                    />
-                  )}
                 </Box>
                 <IconChevronRight size={20} sx={{ flexShrink: 0 }} />
               </Box>

--- a/src/ui/views/TokenDetail/TokenInfoCard.tsx
+++ b/src/ui/views/TokenDetail/TokenInfoCard.tsx
@@ -10,16 +10,12 @@ import receiveIcon from '@/ui/FRWAssets/svg/receiveIcon.svg';
 import sendIcon from '@/ui/FRWAssets/svg/sendIcon.svg';
 import swapIcon from '@/ui/FRWAssets/svg/swapIcon.svg';
 import { IconButton } from '@/ui/FRWComponent/IconButton';
-import { useProfiles } from '@/ui/hooks/useProfileHook';
-import iconMove from 'ui/FRWAssets/svg/move.svg';
 import { useCoins } from 'ui/hooks/useCoinHook';
 
 import IconChevronRight from '../../../components/iconfont/IconChevronRight';
 import VerifiedIcon from '../../FRWAssets/svg/verfied-check.svg';
 
 import { CurrencyValue } from './CurrencyValue';
-
-// import tips from 'ui/FRWAssets/svg/tips.svg';
 
 const TokenInfoCard = ({
   tokenInfo,
@@ -41,7 +37,6 @@ const TokenInfoCard = ({
   );
 
   const balance = extendedTokenInfo?.balance;
-  const { canMoveToChild } = useProfiles();
 
   const toSend = () => {
     history.push(`/dashboard/token/${tokenInfo?.symbol}/send`);
@@ -187,37 +182,6 @@ const TokenInfoCard = ({
               )}
             </Typography>
           </Box>
-          {canMoveToChild && balance && (
-            <ButtonBase onClick={() => toSend()}>
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  background: 'rgba(65, 204, 93, 0.16)',
-                  gap: '4px',
-                  px: '8px',
-                  height: '24px',
-                  borderRadius: '8px',
-                  alignSelf: 'center',
-                }}
-              >
-                <Typography sx={{ fontWeight: '400', fontSize: '12px', color: '#41CC5D' }}>
-                  {chrome.i18n.getMessage('Move')}
-                </Typography>
-                <img
-                  src={iconMove}
-                  alt="Move Icon"
-                  style={{
-                    width: '14px',
-                    height: '14px',
-                    marginLeft: '4px',
-                    filter:
-                      'invert(54%) sepia(78%) saturate(366%) hue-rotate(85deg) brightness(95%) contrast(92%)',
-                  }}
-                />
-              </Box>
-            </ButtonBase>
-          )}
         </Box>
         <Typography variant="body1" color="text.secondary" sx={{ fontSize: '16px' }}>
           <Box component="span" sx={{ marginRight: '0.25rem' }}>

--- a/src/ui/views/TokenDetail/index.tsx
+++ b/src/ui/views/TokenDetail/index.tsx
@@ -37,9 +37,9 @@ const useStyles = makeStyles(() => ({
   container: {
     display: 'flex',
     flexDirection: 'column',
-    gap: '12px',
+    gap: '8px',
     padding: '0 18px',
-    paddingTop: '4px',
+    paddingTop: '0px',
     width: '100%',
     paddingBottom: '18px',
   },
@@ -88,7 +88,7 @@ const TokenDetail = () => {
 
   const Header = () => {
     return (
-      <Box sx={{ display: 'flex', mx: '-12px', position: 'relative' }}>
+      <Box sx={{ display: 'flex', mx: '-12px', position: 'relative', mb: '4px' }}>
         <IconButton onClick={history.goBack}>
           <ArrowBackIcon sx={{ color: 'icon.navi' }} />
         </IconButton>
@@ -204,10 +204,6 @@ const TokenDetail = () => {
             </Box>
           )}
           <TokenInfoCard
-            price={price}
-            token={token}
-            setAccessible={setAccessible}
-            accessible={accessible}
             tokenInfo={tokenInfo}
             accountType={accountType}
             tokenId={tokenId}

--- a/src/ui/views/TokenDetail/index.tsx
+++ b/src/ui/views/TokenDetail/index.tsx
@@ -7,12 +7,9 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 
 import { storage } from '@/background/webapi';
-import type { CoinItem, ExtendedTokenInfo } from '@/shared/types/coin-types';
+import type { CoinItem } from '@/shared/types/coin-types';
 import type { PriceProvider } from '@/shared/types/network-types';
-import {
-  type ActiveAccountType,
-  type ActiveChildType_depreciated,
-} from '@/shared/types/wallet-types';
+import { type ActiveAccountType } from '@/shared/types/wallet-types';
 import StorageUsageCard from '@/ui/FRWComponent/StorageUsageCard';
 import { useCoins } from '@/ui/hooks/useCoinHook';
 import { useProfiles } from '@/ui/hooks/useProfileHook';


### PR DESCRIPTION
Closes #869

## Summary of Changes

Move the "Move" button down a row and style the token name to allow long names. Made more space for the token name by moving the verified token icon as overlay on outside of the token icon.

Overlay outside of token logo just in case scam token tries to add the verified icon to their token logo.

## Need Regression Testing


- [ ] Yes
- [x] No

## Risk Assessment

<!-- Assess the risk level of this PR:
- Low: Minimal impact, straightforward changes.
- Medium: Potential for some edge cases or indirect effects.
- High: Could affect critical functionality or many users.
-->

- [x] Low
- [ ] Medium
- [ ] High

## Additional Notes

![image](https://github.com/user-attachments/assets/ce559162-3f8e-45c5-97d3-aa5c5c0bdfd9)


![image](https://github.com/user-attachments/assets/57916a03-94a5-4667-9e7e-89d22328da8d)



