### PR TITLE
Cache account info when syncing from mobile

### DIFF
--- a/src/background/service/userWallet.ts
+++ b/src/background/service/userWallet.ts
@@ -1286,22 +1286,26 @@ const setupNewAccount = async (
   pubKey: string,
   account: FclAccount
 ): Promise<MainAccount[]> => {
-  // Setup new account after
+  const indexOfKey = account.keys.findIndex((key) => key.publicKey === pubKey);
+  if (indexOfKey === -1) {
+    throw new Error('Key not found');
+  }
+  // Setup new account after registration is complete
   const mainAccounts: MainAccount[] = [
     {
-      keyIndex: account.keys[0].index,
-      weight: account.keys[0].weight,
-      signAlgo: account.keys[0].signAlgo,
-      signAlgoString: account.keys[0].signAlgoString,
-      hashAlgo: account.keys[0].hashAlgo,
-      hashAlgoString: account.keys[0].hashAlgoString,
+      keyIndex: account.keys[indexOfKey].index,
+      weight: account.keys[indexOfKey].weight,
+      signAlgo: account.keys[indexOfKey].signAlgo,
+      signAlgoString: account.keys[indexOfKey].signAlgoString,
+      hashAlgo: account.keys[indexOfKey].hashAlgo,
+      hashAlgoString: account.keys[indexOfKey].hashAlgoString,
       address: withPrefix(account.address) as string,
-      publicKey: account.keys[0].publicKey,
+      publicKey: account.keys[indexOfKey].publicKey,
       chain: networkToChainId(network),
-      id: 0,
-      name: getEmojiByIndex(0).name,
-      icon: getEmojiByIndex(0).emoji,
-      color: getEmojiByIndex(0).bgcolor,
+      id: indexOfKey,
+      name: getEmojiByIndex(indexOfKey).name,
+      icon: getEmojiByIndex(indexOfKey).emoji,
+      color: getEmojiByIndex(indexOfKey).bgcolor,
     },
   ];
 

--- a/src/shared/utils/type.ts
+++ b/src/shared/utils/type.ts
@@ -40,3 +40,12 @@ export enum FCLServiceType {
   localView = 'local-view',
   openID = 'open-id',
 }
+export type FCLWalletConnectSyncAccountInfo = {
+  method: FCLWalletConnectMethod.accountInfo;
+  data: {
+    userAvatar: string;
+    userName: string;
+    walletAddress: string;
+    userId: string;
+  };
+};


### PR DESCRIPTION
## Related Issue

Closes #887

## Summary of Changes

Moved account import logic to wallet and store account which is imported and now stores main account info in a cache for 2 mins until the indexer catches up. Should resolve issue on Android with syncing

## Need Regression Testing


- [X] Yes
- [ ] No

## Risk Assessment
Sync should be verified

- [ ] Low
- [X] Medium
- [ ] High

## Additional Notes

<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)

<!-- Attach any screenshots that help explain your changes -->
