### PR TITLE
Sync mobile and registration status

### DIFF
--- a/e2e/registration/login.test.ts
+++ b/e2e/registration/login.test.ts
@@ -22,6 +22,9 @@ test('Remove profile test', async ({ page, extensionId }) => {
   await fillInPassword({ page, password: keysFile.password });
   await page.getByRole('button', { name: 'Remove' }).click();
 
+  // Wait for the unlock page to load
+  await page.waitForURL(`chrome-extension://${extensionId}/index.html#/unlock`);
+
   // Now login as the test user
   await loginAsTestUser({ page, extensionId });
   // Check that the sender account is not visible

--- a/e2e/transaction/cadence-transaction.test.ts
+++ b/e2e/transaction/cadence-transaction.test.ts
@@ -26,7 +26,7 @@ export const sendTokenFlow = async ({
   await page.getByRole('button', { name: 'Next' }).click();
   await page.getByRole('button', { name: 'Send' }).click();
   // Wait for the transaction to be completed
-  const txId = await waitForTransaction({ page, successtext: 'Executed', ingoreFlowCharge });
+  const txId = await waitForTransaction({ page, successtext: /Executed|Sealed/, ingoreFlowCharge });
   return { txId, tokenname, amount, ingoreFlowCharge };
 };
 
@@ -45,7 +45,7 @@ export const moveTokenFlow = async ({
   await page.getByRole('button', { name: 'Move' }).click();
 
   // Wait for the transaction to be completed
-  const txId = await waitForTransaction({ page, successtext: 'Executed', ingoreFlowCharge });
+  const txId = await waitForTransaction({ page, successtext: /Executed|Sealed/, ingoreFlowCharge });
   return { txId, tokenname, amount, ingoreFlowCharge };
 };
 
@@ -64,7 +64,7 @@ export const moveTokenFlowHomepage = async ({
   await page.getByPlaceholder('Amount').fill(amount);
   await page.getByRole('button', { name: 'Move' }).click();
   // Wait for the transaction to be completed
-  const txId = await waitForTransaction({ page, successtext: 'Executed', ingoreFlowCharge });
+  const txId = await waitForTransaction({ page, successtext: /Executed|Sealed/, ingoreFlowCharge });
   return { txId, tokenname, amount, ingoreFlowCharge };
 };
 

--- a/e2e/utils/helper.ts
+++ b/e2e/utils/helper.ts
@@ -474,6 +474,11 @@ export const waitForTransaction = async ({
   successtext = 'success',
   amount = '',
   ingoreFlowCharge = false,
+}: {
+  page: Page;
+  successtext?: string | RegExp;
+  amount?: string;
+  ingoreFlowCharge?: boolean;
 }) => {
   // Wait for the transaction to be completed
   await page.waitForURL(/.*dashboard\?activity=1.*/);
@@ -483,6 +488,9 @@ export const waitForTransaction = async ({
 
   expect(txId).toBeDefined();
 
+  if (!txId) {
+    throw new Error('Transaction ID is not found');
+  }
   const progressBar = page.getByRole('progressbar');
   await expect(progressBar).toBeVisible();
   // Get the pending item with the cadence txId that was put in the url and status is pending

--- a/src/background/controller/wallet.ts
+++ b/src/background/controller/wallet.ts
@@ -260,9 +260,6 @@ export class WalletController extends BaseController {
 
       userWalletService.registerCurrentPubkey(account.keys[0].publicKey, account);
 
-      // Set the register status cache to false
-      setCachedData(registerStatusKey(account.keys[0].publicKey), false, 120_000);
-
       return account;
     } catch (error) {
       throw new Error(`Account creation failed: ${error.message || 'Unknown error'}`);

--- a/src/background/service/userWallet.ts
+++ b/src/background/service/userWallet.ts
@@ -45,7 +45,7 @@ import {
   accountBalanceRefreshRegex,
 } from '@/shared/utils/cache-data-keys';
 import { retryOperation } from '@/shared/utils/retryOperation';
-import { getUserData, setUserData } from '@/shared/utils/user-data-access';
+import { setUserData } from '@/shared/utils/user-data-access';
 import {
   userWalletsKey,
   type UserWalletStore,
@@ -59,7 +59,6 @@ import {
   type AccountKeyRequest,
   type DeviceInfoRequest,
   type FlowNetwork,
-  type AccountAlgo,
 } from '../../shared/types/network-types';
 import { type PublicKeyAccount, type MainAccount } from '../../shared/types/wallet-types';
 import { type WalletController } from '../controller/wallet';
@@ -204,7 +203,6 @@ class UserWallet {
   };
 
   setNetwork = async (network: string) => {
-    console.trace('setNetwork', network);
     if (!this.store) {
       throw new Error('UserWallet not initialized');
     }
@@ -327,10 +325,8 @@ class UserWallet {
       activeAccounts
     );
     if (
-      validatedActiveAccounts.parentAddress !== null &&
-      validatedActiveAccounts.currentAddress !== null &&
-      (validatedActiveAccounts.parentAddress !== activeAccounts?.parentAddress ||
-        validatedActiveAccounts.currentAddress !== activeAccounts?.currentAddress)
+      validatedActiveAccounts.parentAddress !== activeAccounts?.parentAddress ||
+      validatedActiveAccounts.currentAddress !== activeAccounts?.currentAddress
     ) {
       // Only update the active accounts if they have changed and the addresses are not null
       await setUserData<ActiveAccountsStore>(
@@ -1127,9 +1123,7 @@ const preloadAllAccountsWithPubKey = async (
   }
 
   if (!mainAccounts || mainAccounts.length === 0) {
-    console.warn(
-      `No main accounts loaded even after trying for ${Math.round(MAX_LOAD_TIME / 1000 / 60)} minutes`
-    );
+    console.warn(`No main accounts loaded`);
     return [];
   }
 

--- a/src/background/service/userWallet.ts
+++ b/src/background/service/userWallet.ts
@@ -325,8 +325,10 @@ class UserWallet {
       activeAccounts
     );
     if (
-      validatedActiveAccounts.parentAddress !== activeAccounts?.parentAddress ||
-      validatedActiveAccounts.currentAddress !== activeAccounts?.currentAddress
+      validatedActiveAccounts.parentAddress !== null &&
+      validatedActiveAccounts.currentAddress !== null &&
+      (validatedActiveAccounts.parentAddress !== activeAccounts?.parentAddress ||
+        validatedActiveAccounts.currentAddress !== activeAccounts?.currentAddress)
     ) {
       // Only update the active accounts if they have changed and the addresses are not null
       await setUserData<ActiveAccountsStore>(

--- a/src/ui/hooks/use-account-hooks.ts
+++ b/src/ui/hooks/use-account-hooks.ts
@@ -71,9 +71,22 @@ export const useActiveAccounts = (
   network: string | undefined | null,
   publicKey: string | undefined | null
 ) => {
+  const mainAccounts = useMainAccounts(network, publicKey);
   const activeAccounts = useUserData<ActiveAccountsStore>(
     network && publicKey ? activeAccountsKey(network, publicKey) : null
   );
+  if (!activeAccounts) {
+    // Special case of where main accounts is loaded but we don't have active accounts
+    // This can happen if the user is in the process of registering or when there are no main accounts
+    // In this case we return the main accounts
+    if (mainAccounts && mainAccounts.length === 0) {
+      // There are no main accounts so we return an empty array
+      return {
+        parentAddress: null,
+        currentAddress: null,
+      };
+    }
+  }
   return activeAccounts;
 };
 

--- a/src/ui/views/Dashboard/Header.tsx
+++ b/src/ui/views/Dashboard/Header.tsx
@@ -301,7 +301,7 @@ const Header = ({ _loading = false }) => {
     return (
       <Toolbar sx={{ height: '56px', width: '100%', display: 'flex', px: '0px' }}>
         <Box sx={{ flex: '0 0 68px', position: 'relative', display: 'flex', alignItems: 'center' }}>
-          {(isPending || registerStatus) && (
+          {isPending && (
             <CircularProgress
               size={'28px'}
               sx={{


### PR DESCRIPTION
## Related Issue

Closes #893

<!-- If this PR addresses an issue, link it here  -->

## Summary of Changes

- Now checks that we're on mainnet when importing from mobile
- Removed unnecessary cache setting in WalletController during account registration.
- Enhanced userWallet service to ensure active accounts are only updated when addresses are not null.
- Updated useActiveAccounts hook to handle cases where main accounts are loaded but no active accounts are available, returning null values appropriately.
- Adjusted Header component to only show loading indicator when isPending is true.
## Need Regression Testing


- [X] Yes
- [ ] No

## Risk Assessment


- [ ] Low
- [X] Medium
- [ ] High

## Additional Notes

<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)

<!-- Attach any screenshots that help explain your changes -->
