### PR TITLE
Correct display of tokens without pricing

### DIFF
--- a/src/ui/FRWComponent/TokenLists/TokenItem.tsx
+++ b/src/ui/FRWComponent/TokenLists/TokenItem.tsx
@@ -112,7 +112,11 @@ const TokenItem = ({
             </Box>
           }
           secondary={
-            showSwitch ? <CurrencyValue value={String(token.total)} /> : token.symbol.toUpperCase()
+            showSwitch ? (
+              <CurrencyValue value={token.total?.toString() ?? ''} />
+            ) : (
+              token.symbol.toUpperCase()
+            )
           }
         />
       </CustomListItem>

--- a/src/ui/FRWComponent/TokenLists/TokenItem.tsx
+++ b/src/ui/FRWComponent/TokenLists/TokenItem.tsx
@@ -12,6 +12,8 @@ import {
 import { styled } from '@mui/material/styles';
 import React from 'react';
 
+import { CurrencyValue } from '@/ui/views/TokenDetail/CurrencyValue';
+
 import IconCheckmark from '../../../components/iconfont/IconCheckmark';
 import IconPlus from '../../../components/iconfont/IconPlus';
 import VerifiedIcon from '../../FRWAssets/svg/verfied-check.svg';
@@ -110,9 +112,7 @@ const TokenItem = ({
             </Box>
           }
           secondary={
-            showSwitch
-              ? `$${isNaN(parseFloat(token.total)) ? '0.00' : parseFloat(token.total).toFixed(5).toLocaleString()}`
-              : token.symbol.toUpperCase()
+            showSwitch ? <CurrencyValue value={String(token.total)} /> : token.symbol.toUpperCase()
           }
         />
       </CustomListItem>

--- a/src/ui/views/TokenDetail/TokenValue.tsx
+++ b/src/ui/views/TokenDetail/TokenValue.tsx
@@ -18,7 +18,7 @@ export const TokenValue: React.FC<TokenPriceProps> = ({
   postFix = '',
 }) => {
   if (!value || value === '0' || value === '') {
-    return <span className={className}>{'$0.00'}</span>;
+    return <span className={className}>&nbsp;</span>;
   }
 
   const { formattedPrice } = formatPrice(value);


### PR DESCRIPTION
## Related Issue

Closes #925


## Summary of Changes
Now displays blank space when there is no pricing information for a token

## Need Regression Testing

- [ ] Yes
- [X] No

## Risk Assessment
Front end only change

- [X] Low
- [ ] Medium
- [ ] High

## Additional Notes

<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/09fc6d5e-8fb9-472b-a6e9-853159e92170)
![image](https://github.com/user-attachments/assets/dfe6071d-6098-461c-85a5-86c184f1d538)

