### PR TITLE
896-task-host-playwright-reports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -231,7 +231,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: playwright-report
-          path: playwright-report
+          path: temp-playwright-report
+      - name: Move report to run-specific directory
+        run: |
+          mkdir -p playwright-report/runs/${{ github.run_id }}
+          cp -r temp-playwright-report/* playwright-report/runs/${{ github.run_id }}/
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Upload artifact
@@ -241,3 +245,7 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+      - name: Add Playwright Report Annotation
+        if: always()
+        run: |
+          echo "::notice title=Playwright Report::View the Playwright report for this run at https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPOSITORY#*/}/runs/${GITHUB_RUN_ID}/"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,3 +216,28 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
+
+  deploy-report:
+    needs: [test]
+    runs-on: ubuntu-latest
+    if: always()
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download Playwright Report
+        uses: actions/download-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: playwright-report
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION

## Related Issue

Closes #896

## Summary of Changes

Reports are now hosted on github pages. You can see the report for this pr in the annotations. Note that we only store the screenshots for test failures

## Need Regression Testing

- [ ] Yes
- [X] No

## Risk Assessment

- [X] Low
- [ ] Medium
- [ ] High

## Additional Notes

<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)

Click Playright Report then the link that appears in the action run after that to take a look. Or just [click here](https://onflow.github.io/FRW-Extension/runs/14923807632/)

<img width="912" alt="image" src="https://github.com/user-attachments/assets/5cb3746a-88b9-4733-8b54-0d8208175f1b" />

