### PR TITLE
954-bug-signing-transactions-after-logout

### DIFF
--- a/src/background/service/notification.ts
+++ b/src/background/service/notification.ts
@@ -53,8 +53,8 @@ class NotificationService extends Events {
     winMgr.event.on('windowRemoved', (winId: number) => {
       if (winId === this.notifiWindowId) {
         this.notifiWindowId = 0;
+        this.rejectApproval();
       }
-      this.rejectApproval();
     });
 
     winMgr.event.on('windowFocusChange', (winId: number) => {

--- a/src/ui/utils/hooks.ts
+++ b/src/ui/utils/hooks.ts
@@ -62,12 +62,6 @@ export const useApproval = () => {
     [getApproval, stableUsewallet, stableHistory]
   );
 
-  useEffect(() => {
-    window.addEventListener('beforeunload', rejectApproval);
-
-    return () => window.removeEventListener('beforeunload', rejectApproval);
-  }, [rejectApproval]);
-
   return [getApproval, resolveApproval, rejectApproval, linkingConfirm] as const;
 };
 


### PR DESCRIPTION


## Related Issue

Closes #954

## Summary of Changes

Removed the useEffect on the front end notification component that was calling reject when the window unloaded
Adjusted the background listener that listens for window closing to check if the id of the window is the same as the current notification before rejecting.

This should fix the issues seen trying to send transactions from a locked wallet. It should unlock first, then ask the user to approve the transaction.

## Need Regression Testing

Should test dApp connections - cancelling by closing the window, and trying to sign transacitons from locked state

- [X] Yes
- [ ] No

## Risk Assessment

Low risk I'd say

- [X] Low
- [ ] Medium
- [ ] High


