### PR TITLE
Host santised reports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,11 +146,20 @@ jobs:
       group: tests-${{ github.workflow }}
       cancel-in-progress: false
     environment: ${{ needs.determine-env.outputs.env_name }}
+    strategy:
+      matrix:
+        node-version: [22.x]
+
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
 
       - name: Download build artifacts
@@ -202,18 +211,19 @@ jobs:
     needs: [test] # Depends on the Playwright test job
     runs-on: ubuntu-latest
     if: always() # Run even if tests fail to publish what's available
+    strategy:
+      matrix:
+        node-version: [22.x]
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Required by Chromatic
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Use Node.js
+      - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,6 +216,8 @@ jobs:
         node-version: [22.x]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history for tags
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,6 +151,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
+          cache: 'pnpm'
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -212,7 +213,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22.x' # Or your project's Node version
+          node-version: lts/*
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -224,21 +225,17 @@ jobs:
           name: playwright-report
           path: playwright-report/ # Download to this path
 
+      - name: Deploy Playwright Report
+        uses: peaceiris/actions-gh-pages@v4
+        if: always() # Deploy even if tests fail
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./playwright-report
+          destination_dir: reports/run-${{ github.run_id }}
+          keep_files: true
+
       - name: Build Storybook
         run: pnpm build-storybook # Assumes output is storybook-static
-
-      - name: Copy Playwright report to Storybook static
-        run: |
-          mkdir -p storybook-static/test-results
-          if [ -d "playwright-report" ]; then
-            cp -r playwright-report storybook-static/test-results/playwright-report
-            echo "Playwright report copied to storybook-static/test-results/playwright-report"
-          else
-            echo "Playwright report not found. Skipping copy."
-            echo "Creating placeholder Playwright report..."
-            mkdir -p storybook-static/test-results/playwright-report
-            echo "<html><body><h1>Playwright report not found.</h1></body></html>" > storybook-static/test-results/playwright-report/index.html
-          fi
 
       - name: Publish to Chromatic
         uses: chromaui/action@v1
@@ -247,3 +244,20 @@ jobs:
           storybookBuildDir: storybook-static # Directory with Storybook and reports
           exitZeroOnChanges: true # Optional: useful for PR checks
           # workingDir: . # Not needed if storybookBuildDir is set correctly
+
+      - name: Add Job Summary
+        if: always()
+        run: |
+          echo "## 🎭 Playwright Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### 📊 Report Details" >> $GITHUB_STEP_SUMMARY
+          echo "- **Run ID**: ${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Branch**: ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit**: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Triggered by**: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### 🔗 Links" >> $GITHUB_STEP_SUMMARY
+          echo "- 📋 **[View Full Report](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/reports/run-${{ github.run_id }}/)**" >> $GITHUB_STEP_SUMMARY
+          echo "- 📁 **[All Reports](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/)**" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "> 💡 **Tip**: Click the report link above to view detailed test results, traces, and screenshots!" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,6 +237,9 @@ jobs:
           name: playwright-report
           path: playwright-report/ # Download to this path
 
+      - name: Create .nojekyll file
+        run: touch playwright-report/.nojekyll
+
       - name: Deploy Playwright Report
         uses: peaceiris/actions-gh-pages@v4
         if: always() # Deploy even if tests fail

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -273,6 +273,5 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### 🔗 Links" >> $GITHUB_STEP_SUMMARY
           echo "- 📋 **[View Full Report](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/reports/run-${{ github.run_id }}/)**" >> $GITHUB_STEP_SUMMARY
-          echo "- 📁 **[All Reports](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/)**" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "> 💡 **Tip**: Click the report link above to view detailed test results, traces, and screenshots!" >> $GITHUB_STEP_SUMMARY

--- a/build/__tests__/sanitize-playwright.test.ts
+++ b/build/__tests__/sanitize-playwright.test.ts
@@ -1,0 +1,113 @@
+/// <reference types="vitest" />
+import { type Stats } from 'fs';
+import fs from 'fs/promises';
+import path from 'path';
+
+import JSZip from 'jszip';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+import { loadSecrets, scrubValue, sanitizeTrace } from '../sanitize-playwright';
+
+vi.mock('jszip', () => {
+  const mockJszipInstance = {
+    file: vi.fn().mockReturnThis(),
+    generateAsync: vi.fn().mockResolvedValue('mock-zip-data'),
+    files: {},
+  };
+  const JSZip = {
+    loadAsync: vi.fn().mockResolvedValue(mockJszipInstance),
+  };
+  return {
+    __esModule: true,
+    default: JSZip,
+  };
+});
+
+describe('sanitize-playwright', () => {
+  const secrets = ['secret-value', 'another-secret'];
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('loadSecrets', () => {
+    it('should load secrets from .env files', async () => {
+      const projectRoot = process.cwd();
+      const envContent = `SECRET_KEY=secret-value
+ANOTHER_KEY="another-secret"`;
+      const readdirSpy = vi.spyOn(fs, 'readdir').mockResolvedValue(['.env', '.env.test'] as any);
+      const readFileSpy = vi.spyOn(fs, 'readFile').mockResolvedValue(envContent);
+
+      const loadedSecrets = await loadSecrets();
+      expect(loadedSecrets).toContain('secret-value');
+      expect(loadedSecrets).toContain('another-secret');
+      expect(readdirSpy).toHaveBeenCalledWith(projectRoot);
+      expect(readFileSpy).toHaveBeenCalledWith(path.join(projectRoot, '.env'), 'utf-8');
+      expect(readFileSpy).toHaveBeenCalledWith(path.join(projectRoot, '.env.test'), 'utf-8');
+    });
+  });
+
+  describe('scrubValue', () => {
+    it('should scrub secrets from a nested object', () => {
+      const obj = {
+        key1: 'this contains a secret-value',
+        key2: {
+          nestedKey: 'and another-secret here',
+        },
+        keySeed: 'test test test test test test test test test test test junk',
+        key3: 'this is safe',
+      };
+
+      scrubValue(obj, secrets);
+
+      expect(obj.key1).toBe('this contains a ********');
+      expect(obj.key2.nestedKey).toBe('and ******** here');
+      expect(obj.key3).toBe('this is safe');
+      expect(obj.keySeed).toBe('********');
+    });
+  });
+
+  describe('sanitizeTrace', () => {
+    const tracePath = '/fake/dir/trace.zip';
+
+    it('should sanitize a trace file', async () => {
+      const traceContent = JSON.stringify({
+        type: 'action',
+        params: { value: 'a secret-value' },
+      });
+      const zipBuffer = Buffer.from('zip file content');
+
+      const statSpy = vi.spyOn(fs, 'stat').mockResolvedValue({ isFile: () => true } as Stats);
+      const readFileSpy = vi.spyOn(fs, 'readFile').mockResolvedValue(zipBuffer);
+      const writeFileSpy = vi.spyOn(fs, 'writeFile').mockResolvedValue();
+
+      const traceFile = {
+        name: 'trace.trace',
+        async: vi.fn().mockResolvedValue(traceContent),
+      };
+
+      const mockedLoadAsync = vi.mocked(JSZip.loadAsync);
+      mockedLoadAsync.mockResolvedValue({
+        files: { 'trace.trace': traceFile },
+        file: vi.fn().mockReturnThis(),
+        generateAsync: vi.fn().mockResolvedValue('mock-zip-data'),
+      } as any);
+
+      await sanitizeTrace(tracePath, secrets);
+
+      expect(readFileSpy).toHaveBeenCalledWith(tracePath);
+      expect(mockedLoadAsync).toHaveBeenCalledWith(zipBuffer);
+      expect(traceFile.async).toHaveBeenCalledWith('string');
+      const loadedZip = await mockedLoadAsync.mock.results[0].value;
+      expect(loadedZip.file).toHaveBeenCalledWith(
+        'trace.trace',
+        JSON.stringify({
+          type: 'action',
+          params: { value: 'a ********' },
+        })
+      );
+      expect(loadedZip.generateAsync).toHaveBeenCalled();
+      expect(writeFileSpy).toHaveBeenCalledWith(tracePath, 'mock-zip-data');
+    });
+  });
+});

--- a/build/sanitize-playwright.ts
+++ b/build/sanitize-playwright.ts
@@ -135,9 +135,8 @@ async function sanitizeAllTraces() {
   const secrets = await loadSecrets();
 
   if (!(await fs.stat(dataDir).catch(() => false))) {
-    console.error(`Data directory not found: ${dataDir}`);
-    console.error('Please provide a valid Playwright report directory.');
-    process.exit(1);
+    console.info(`No reports to sanitize in: ${dataDir}`);
+    return;
   }
 
   const files = await fs.readdir(dataDir);


### PR DESCRIPTION
## Related Issue

Closes #1034


## Summary of Changes

Santised reports will now be hosted on github pages. The data is uploaded to branch and we use a popular third party action to retain the previous runs. In addition to the santize script (which now has tests in this PR), we have secret protection on the repo as well, so if the action tries to check in anything on gh-pages branch with a secret, the checkin action will be detected.

## Need Regression Testing
Not affecting core code

- [ ] Yes
- [X] No

## Risk Assessment
Changing how reports are hosted

- [X] Low
- [ ] Medium
- [ ] High


## Screenshots (if applicable)

<!-- Attach any screenshots that help explain your changes -->
