### PR TITLE
1060-feature-add-beta-to-icon-for-pre-release-build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,12 +8,24 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       env_name: ${{ steps.set_env.outputs.env_name }}
+      is_beta: ${{ steps.set_env.outputs.is_beta }}
+      beta_version: ${{ steps.set_env.outputs.beta_version }}
     steps:
       - id: set_env
         run: |
           ENV_NAME="${{ github.ref_type == 'tag' && 'production' || github.ref_name == 'master' && 'production' || github.ref_name == 'dev' && 'staging' || 'development' }}"
+          IS_BETA="false"
+          BETA_VERSION=""
+          if [[ "${{ github.ref_type }}" == "tag" && "${{ github.ref_name }}" == *"beta"* ]]; then
+            IS_BETA="true"
+            BETA_VERSION="${{ github.ref_name }}"
+          fi
           echo "env_name=$ENV_NAME" >> $GITHUB_OUTPUT
+          echo "is_beta=$IS_BETA" >> $GITHUB_OUTPUT
+          echo "beta_version=$BETA_VERSION" >> $GITHUB_OUTPUT
           echo "Environment name: $ENV_NAME"
+          echo "Is beta: $IS_BETA"
+          echo "Beta version: $BETA_VERSION"
 
   build:
     needs: determine-env
@@ -57,6 +69,9 @@ jobs:
         run: pnpm install
 
       - name: Create environment files
+        env:
+          IS_BETA: ${{ needs.determine-env.outputs.is_beta }}
+          BETA_VERSION: ${{ needs.determine-env.outputs.beta_version }}
         run: |
           # Function to create environment file with given name
           create_env_file() {
@@ -70,6 +85,8 @@ jobs:
           DEPLOYMENT_ENV="${{ needs.determine-env.outputs.env_name }}"
           LATEST_TAG="${{ env.LATEST_TAG }}"
           REPO_URL="${{ env.REPO_URL }}"
+          IS_BETA="${{ env.IS_BETA }}"
+          BETA_VERSION="${{ env.BETA_VERSION }}"
 
           # Google drive
           GD_BACKUP_NAME="${{ vars.GD_BACKUP_NAME }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,6 +99,7 @@ jobs:
           WC_PROJECTID="${{ secrets.WC_PROJECTID }}"
           MIXPANEL_TOKEN="${{ secrets.MIXPANEL_TOKEN }}"
           SCRIPTS_PUBLIC_KEY="${{ vars.SCRIPTS_PUBLIC_KEY }}"
+          BETA_MANIFEST_KEY="${{ secrets.BETA_MANIFEST_KEY }}"
           EOF
           }
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Get latest tag
         id: latest_tag
         run: |
-          LATEST_TAG=$(git tag --sort=-committerdate | head -n 1 || echo "v0.0.0")
+          LATEST_TAG=$(git tag --sort=-committerdate | grep -v "beta" | head -n 1 || echo "v0.0.0")
           echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
           echo "Latest tag: $LATEST_TAG"
 
@@ -117,6 +117,7 @@ jobs:
           MIXPANEL_TOKEN="${{ secrets.MIXPANEL_TOKEN }}"
           SCRIPTS_PUBLIC_KEY="${{ vars.SCRIPTS_PUBLIC_KEY }}"
           BETA_MANIFEST_KEY="${{ secrets.BETA_MANIFEST_KEY }}"
+          BETA_OAUTH2_CLIENT_ID="${{ secrets.BETA_OAUTH2_CLIENT_ID }}"
           EOF
           }
 

--- a/build/prepareManifest.ts
+++ b/build/prepareManifest.ts
@@ -63,6 +63,7 @@ async function prepare() {
 
     manifest.name = '__MSG_appNameBeta__';
     manifest.description = '__MSG_appDescriptionBeta__';
+    manifest.key = process.env.BETA_MANIFEST_KEY;
   } else {
     manifest.version = version;
     manifest.name = '__MSG_appName__';

--- a/build/prepareManifest.ts
+++ b/build/prepareManifest.ts
@@ -65,6 +65,7 @@ async function prepare() {
     manifest.name = '__MSG_appNameBeta__';
     manifest.description = '__MSG_appDescriptionBeta__';
     manifest.key = process.env.BETA_MANIFEST_KEY;
+    manifest.oauth2.client_id = process.env.BETA_OAUTH2_CLIENT_ID;
   } else {
     manifest.version = version;
     manifest.name = '__MSG_appName__';

--- a/build/prepareManifest.ts
+++ b/build/prepareManifest.ts
@@ -20,6 +20,7 @@ const mode = args[0];
 
 dotenv.config({ path: `.env.${mode}` });
 
+const IS_BETA = process.env.IS_BETA === 'true';
 const OAUTH2_SCOPES = process.env.OAUTH2_SCOPES || '';
 
 const DEVTOOLS_URL = 'http://localhost:8097';
@@ -58,7 +59,7 @@ async function prepare() {
     scopes: OAUTH2_SCOPES.split(','),
   };
   // Update the version in the manifest
-  if (version.includes('beta')) {
+  if (IS_BETA) {
     manifest.version = version.replace(/^(\d+\.\d+\.\d+).*/, '$1');
 
     manifest.name = '__MSG_appNameBeta__';

--- a/src/background/utils/setEnvironmentBadge.ts
+++ b/src/background/utils/setEnvironmentBadge.ts
@@ -1,11 +1,12 @@
 // Set environment badge based on branch
+const IS_BETA = process.env.IS_BETA === 'true';
 
 export const setEnvironmentBadge = () => {
   const deploymentEnv = process.env.DEPLOYMENT_ENV;
 
   if (deploymentEnv === 'production') {
     // No badge for production
-    if (process.env.BETA_MANIFEST_KEY) {
+    if (IS_BETA) {
       chrome.action.setBadgeText({ text: 'β' });
     } else {
       chrome.action.setBadgeText({ text: '' });

--- a/src/background/utils/setEnvironmentBadge.ts
+++ b/src/background/utils/setEnvironmentBadge.ts
@@ -5,7 +5,11 @@ export const setEnvironmentBadge = () => {
 
   if (deploymentEnv === 'production') {
     // No badge for production
-    chrome.action.setBadgeText({ text: '' });
+    if (process.env.BETA_MANIFEST_KEY) {
+      chrome.action.setBadgeText({ text: 'β' });
+    } else {
+      chrome.action.setBadgeText({ text: '' });
+    }
   } else if (deploymentEnv === 'staging') {
     chrome.action.setBadgeText({ text: 'stg' });
   } else if (deploymentEnv === 'development') {

--- a/src/shared/utils/message/index.ts
+++ b/src/shared/utils/message/index.ts
@@ -66,14 +66,14 @@ abstract class Message extends EventEmitter {
         res = await this.listenCallback(data);
       } catch (e: any) {
         err = {
-          message: e.message,
-          stack: e.stack,
+          message: e?.message || 'Unknown error',
+          stack: e?.stack || 'Unknown stack',
         };
-        if (e.code) {
-          err.code = e.code;
+        if (e?.code) {
+          err.code = e?.code;
         }
-        if (e.data) {
-          err.data = e.data;
+        if (e?.data) {
+          err.data = e?.data;
         }
       }
 

--- a/src/ui/components/build-indicator.tsx
+++ b/src/ui/components/build-indicator.tsx
@@ -1,0 +1,98 @@
+import { Box, Chip, Tooltip, Typography } from '@mui/material';
+import React, { useCallback } from 'react';
+
+import packageJson from '../../../package.json' assert { type: 'json' };
+const { version } = packageJson;
+import { COLOR_PRIMARY_TEXT_282828 } from '../style/color';
+
+const deploymentEnv = process.env.DEPLOYMENT_ENV || 'local';
+const isBeta = process.env.IS_BETA === 'true';
+const betaVersion = process.env.BETA_VERSION || '';
+
+export const BuildIndicator = () => {
+  // Function to construct GitHub comparison URL
+  const getComparisonUrl = useCallback(() => {
+    const repoUrl = process.env.REPO_URL || 'https://github.com/onflow/FRW-Extension';
+    const latestTag = process.env.LATEST_TAG || '';
+    const commitSha = process.env.COMMIT_SHA || '';
+
+    if (latestTag && commitSha) {
+      return `${repoUrl}/compare/${latestTag}...${commitSha}`;
+    }
+
+    return `${repoUrl}/commits`;
+  }, []);
+
+  if (deploymentEnv === 'production' && !isBeta) {
+    return null;
+  }
+
+  const buildText = isBeta ? `${version}-beta-${betaVersion}` : `${deploymentEnv} build`;
+  const latestTag = process.env.LATEST_TAG || '';
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        display: 'flex',
+        position: 'absolute',
+        justifyContent: 'flex-end',
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          position: 'absolute',
+          padding: { xs: '0 8px', sm: '0 16px', md: '0 24px' },
+          margin: { xs: '0', sm: '0 16px', md: '0 24px' },
+          borderRadius: '0 0 16px 16px',
+          backgroundColor: COLOR_PRIMARY_TEXT_282828,
+        }}
+      >
+        <Tooltip
+          title={
+            <Box>
+              <Typography variant="caption">{`Build: ${process.env.DEPLOYMENT_ENV}`}</Typography>
+              {process.env.LATEST_TAG && process.env.COMMIT_SHA && (
+                <Typography variant="caption" display="block">
+                  {`Compare: ${process.env.LATEST_TAG}...${process.env.COMMIT_SHA?.substring(0, 7)}`}
+                </Typography>
+              )}
+              <Typography variant="caption" display="block">
+                {`Repo: ${process.env.REPO_URL?.replace('https://github.com/', '') || 'onflow/FRW-Extension'}`}
+              </Typography>
+              <Typography variant="caption" display="block">
+                Click to view changes
+              </Typography>
+            </Box>
+          }
+          arrow
+        >
+          <Typography
+            color={
+              deploymentEnv === 'staging' || isBeta
+                ? 'default'
+                : deploymentEnv === 'development'
+                  ? 'warning'
+                  : 'error'
+            }
+            sx={{
+              height: '18px',
+              fontSize: '10px',
+              fontWeight: 'bold',
+              minWidth: '16px',
+              maxWidth: '90px',
+              cursor: 'pointer',
+            }}
+            onClick={() => {
+              const url = getComparisonUrl();
+              window.open(url, '_blank');
+            }}
+          >
+            {buildText}
+          </Typography>
+        </Tooltip>
+      </Box>
+    </Box>
+  );
+};

--- a/src/ui/components/build-indicator.tsx
+++ b/src/ui/components/build-indicator.tsx
@@ -7,7 +7,7 @@ import { COLOR_PRIMARY_TEXT_282828 } from '../style/color';
 
 const deploymentEnv = process.env.DEPLOYMENT_ENV || 'local';
 const isBeta = process.env.IS_BETA === 'true';
-const betaVersion = process.env.BETA_VERSION || '';
+const betaVersion = process.env.BETA_VERSION || ''; // This is the whole tag name like 2.8.5-beta.1
 
 export const BuildIndicator = () => {
   // Function to construct GitHub comparison URL
@@ -27,8 +27,7 @@ export const BuildIndicator = () => {
     return null;
   }
 
-  const buildText = isBeta ? `${version}-beta-${betaVersion}` : `${deploymentEnv} build`;
-  const latestTag = process.env.LATEST_TAG || '';
+  const buildText = isBeta ? betaVersion : `${deploymentEnv} build`;
   return (
     <Box
       sx={{

--- a/src/ui/views/Dashboard/Header.tsx
+++ b/src/ui/views/Dashboard/Header.tsx
@@ -192,19 +192,6 @@ const Header = ({ _loading = false }) => {
     };
   }, [checkAuthStatus, checkPendingTx, network]);
 
-  // Function to construct GitHub comparison URL
-  const getComparisonUrl = useCallback(() => {
-    const repoUrl = process.env.REPO_URL || 'https://github.com/onflow/FRW-Extension';
-    const latestTag = process.env.LATEST_TAG || '';
-    const commitSha = process.env.COMMIT_SHA || '';
-
-    if (latestTag && commitSha) {
-      return `${repoUrl}/compare/${latestTag}...${commitSha}`;
-    }
-
-    return `${repoUrl}/commits`;
-  }, []);
-
   const NewsDrawer = () => {
     return (
       <Drawer
@@ -225,7 +212,6 @@ const Header = ({ _loading = false }) => {
       </Drawer>
     );
   };
-  const deploymentEnv = process.env.DEPLOYMENT_ENV || 'local';
 
   interface AppBarLabelProps {
     address: string;
@@ -253,62 +239,6 @@ const Header = ({ _loading = false }) => {
             spinning={isPending}
             onClick={toggleDrawer}
           />
-
-          {deploymentEnv !== 'production' && (
-            <Box sx={{ position: 'absolute', left: '50px', top: '-8px', zIndex: 10 }}>
-              <Tooltip
-                title={
-                  <Box>
-                    <Typography variant="caption">
-                      {`Build: ${process.env.DEPLOYMENT_ENV}`}
-                    </Typography>
-                    {process.env.LATEST_TAG && process.env.COMMIT_SHA && (
-                      <Typography variant="caption" display="block">
-                        {`Compare: ${process.env.LATEST_TAG}...${process.env.COMMIT_SHA?.substring(0, 7)}`}
-                      </Typography>
-                    )}
-                    <Typography variant="caption" display="block">
-                      {`Repo: ${process.env.REPO_URL?.replace('https://github.com/', '') || 'onflow/FRW-Extension'}`}
-                    </Typography>
-                    <Typography variant="caption" display="block">
-                      Click to view changes
-                    </Typography>
-                  </Box>
-                }
-                arrow
-              >
-                <Chip
-                  label={deploymentEnv}
-                  size="small"
-                  color={
-                    deploymentEnv === 'staging'
-                      ? 'default'
-                      : deploymentEnv === 'development'
-                        ? 'warning'
-                        : 'error'
-                  }
-                  sx={{
-                    height: '18px',
-                    fontSize: '10px',
-                    fontWeight: 'bold',
-                    minWidth: '16px',
-                    maxWidth: '90px',
-                    cursor: 'pointer',
-                    '& .MuiChip-label': {
-                      padding: '0 8px',
-                      whiteSpace: 'nowrap',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                    },
-                  }}
-                  onClick={() => {
-                    const url = getComparisonUrl();
-                    window.open(url, '_blank');
-                  }}
-                />
-              </Tooltip>
-            </Box>
-          )}
         </Box>
 
         <Box

--- a/src/ui/views/Dashboard/index.tsx
+++ b/src/ui/views/Dashboard/index.tsx
@@ -1,7 +1,6 @@
 import Box from '@mui/material/Box';
 import React from 'react';
 
-import { BuildChip } from '@/ui/components/build-chip';
 import { BuildIndicator } from '@/ui/components/build-indicator';
 import { NetworkIndicator } from '@/ui/components/NetworkIndicator';
 import { useNetwork } from '@/ui/hooks/useNetworkHook';

--- a/src/ui/views/Dashboard/index.tsx
+++ b/src/ui/views/Dashboard/index.tsx
@@ -1,6 +1,8 @@
 import Box from '@mui/material/Box';
 import React from 'react';
 
+import { BuildChip } from '@/ui/components/build-chip';
+import { BuildIndicator } from '@/ui/components/build-indicator';
 import { NetworkIndicator } from '@/ui/components/NetworkIndicator';
 import { useNetwork } from '@/ui/hooks/useNetworkHook';
 
@@ -20,6 +22,7 @@ const Dashboard = () => {
           flexDirection: 'column',
         }}
       >
+        <BuildIndicator />
         <NetworkIndicator network={network} emulatorMode={emulatorModeOn} />
         <div test-id="x-overflow" style={{ overflowX: 'hidden', height: '100%' }}>
           <div style={{ display: 'block', width: '100%' }}>

--- a/src/ui/views/Setting/About/About.tsx
+++ b/src/ui/views/Setting/About/About.tsx
@@ -9,6 +9,7 @@ import discord from 'ui/assets/image/discord.png';
 import lilo from 'ui/assets/image/lilo.png';
 import X from 'ui/assets/svg/xLogo.svg';
 const { version } = packageJson;
+const BETA_VERSION = process.env.BETA_VERSION;
 // import '../../Unlock/style.css';
 
 const useStyles = makeStyles(() => ({
@@ -109,6 +110,7 @@ const About = () => {
           sx={{ textAlign: 'center', fontWeight: 300 }}
         >
           {chrome.i18n.getMessage('Version')} {`${version}`}
+          {BETA_VERSION && ` (${BETA_VERSION})`}
         </Typography>
 
         {process.env.DEPLOYMENT_ENV !== 'production' && (


### PR DESCRIPTION
## Related Issue

Closes #1060


## Summary of Changes

- Now uses git tag to create the beta build instead of the version number. Create a tag in the form x.y.z-beta-x
- Added BETA_OAUTH2_CLIENT_ID so that the beta verson can create and accees its own google backups
- Moved the chip form the account menu as it was kinda in the way. 
- Introduced BuildIndicator component to display build information and comparison links.
- Updated GitHub Actions workflow to exclude beta tags when fetching the latest tag.
- Improved error handling in the Message class to provide default values for error properties.
- Removed redundant GitHub comparison URL logic from Header component.


## Need Regression Testing

- [ ] Yes
- [X] No

## Risk Assessment

- [X] Low
- [ ] Medium
- [ ] High

## Additional Notes

<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)
<img width="430" alt="Screenshot 2025-06-16 at 1 38 42 pm" src="https://github.com/user-attachments/assets/7fef6744-7132-4636-8f7e-0097e9a5d158" />
<img width="430" alt="Screenshot 2025-06-16 at 1 42 54 pm" src="https://github.com/user-attachments/assets/9f3d83a1-fcf1-4058-a7a4-f1002f1046e1" />

