### PR TITLE
Update MUI styles from makeStyles to sx

### DIFF
--- a/src/ui/views/EmptyStatus.tsx
+++ b/src/ui/views/EmptyStatus.tsx
@@ -1,42 +1,19 @@
 import { Typography, Box } from '@mui/material';
-import { makeStyles } from '@mui/styles';
 import React from 'react';
 
 import empty_status from '@/ui/assets/image/empty_status.svg';
 
-const useStyles = makeStyles(() => ({
-  emptyBox: {
-    height: '249px',
-    justifyContent: 'center',
-    alignContent: 'center',
-    textAlign: 'center',
-  },
-  emptyImg: {
-    margin: '0 auto auto auto',
-  },
-  title: {
-    fontSize: '16px',
-    lineHeight: '24px',
-    fontWeight: 600,
-    marginTop: '16px',
-    marginBottom: '4px',
-    width: '100%',
-    color: '#8C8C8C',
-  },
-  subtitle: {
-    fontSize: '14px',
-    lineHeight: '20px',
-    width: '100%',
-    color: '#8C8C8C',
-  },
-}));
-
 function EmptyStatus() {
-  const classes = useStyles();
-
   return (
-    <Box className={classes.emptyBox}>
-      <img className={classes.emptyImg} src={empty_status} height="167px" />
+    <Box
+      sx={{
+        height: '249px',
+        justifyContent: 'center',
+        alignContent: 'center',
+        textAlign: 'center',
+      }}
+    >
+      <img src={empty_status} height="167px" style={{ margin: '0 auto auto auto' }} />
       <Typography
         sx={{
           fontSize: '16px',

--- a/src/ui/views/Setting/About/About.tsx
+++ b/src/ui/views/Setting/About/About.tsx
@@ -1,5 +1,4 @@
 import { Typography, Box, CardMedia } from '@mui/material';
-import { makeStyles } from '@mui/styles';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 
@@ -12,77 +11,25 @@ const { version } = packageJson;
 const BETA_VERSION = process.env.BETA_VERSION;
 // import '../../Unlock/style.css';
 
-const useStyles = makeStyles(() => ({
-  arrowback: {
-    borderRadius: '100%',
-    margin: '8px',
-  },
-  iconbox: {
-    position: 'sticky',
-    top: 0,
-    width: '100%',
-    minWidth: '100%',
-    // backgroundColor: '#121212',
-    margin: 0,
-    padding: 0,
-    justifyContent: 'space-between',
-  },
-  aboutTitle: {
-    zIndex: 20,
-    textAlign: 'center',
-    top: 0,
-    position: 'sticky',
-  },
-  list: {
-    width: '90%',
-    margin: '80px auto',
-    padding: 0,
-  },
-  listItem: {
-    width: '100%',
-    padding: '24px 0',
-  },
-  itemButton: {
-    margin: 0,
-  },
-  logoBox: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '2px',
-    alignItems: 'center',
-  },
-  mediaBox: {
-    width: '65%',
-    margin: '72px auto 16px auto',
-    alignItems: 'center',
-  },
-  logo: {
-    width: '84px',
-    height: '84px',
-    margin: '0 auto',
-  },
-  iconsBox: {
-    width: '100%',
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-  },
-}));
-
 const BRANCH_NAME = process.env.BRANCH_NAME;
 
 const COMMIT_SHA = process.env.COMMIT_SHA;
 
 const About = () => {
-  const classes = useStyles();
-
   const history = useHistory();
 
   return (
     <div className="page">
       <LLHeader title="" help={true} />
 
-      <Box className={classes.logoBox}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '2px',
+          alignItems: 'center',
+        }}
+      >
         {/* <img src={logo} alt='logo' className={classes.logo} /> */}
 
         <a href="https://wallet.flow.com" target="_blank">
@@ -142,7 +89,13 @@ const About = () => {
         )}
       </Box>
 
-      <Box className={classes.mediaBox}>
+      <Box
+        sx={{
+          width: '65%',
+          margin: '72px auto 16px auto',
+          alignItems: 'center',
+        }}
+      >
         <Typography
           variant="body1"
           component="div"
@@ -151,8 +104,13 @@ const About = () => {
           {chrome.i18n.getMessage('CONTACT__US')}
         </Typography>
         <Box
-          className={classes.iconsBox}
-          sx={{ width: '100%', display: 'flex', flexDirection: 'row', alignItems: 'center' }}
+          sx={{
+            width: '100%',
+            display: 'flex',
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
         >
           <a href="https://discord.com/invite/J6fFnh2xx6" target="_blank" style={{ width: '58px' }}>
             <Box

--- a/src/ui/views/Setting/AddressBook/index.tsx
+++ b/src/ui/views/Setting/AddressBook/index.tsx
@@ -14,7 +14,6 @@ import {
 } from '@mui/material';
 import InputAdornment from '@mui/material/InputAdornment';
 import { StyledEngineProvider } from '@mui/material/styles';
-import { makeStyles } from '@mui/styles';
 import _ from 'lodash';
 import React, { useState, useEffect, useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
@@ -27,45 +26,11 @@ import { useWallet } from 'ui/utils';
 import AddOrEditAddress from './AddOrEditAddress';
 import AddressBookItem from './AddressBookItem';
 
-const useStyles = makeStyles((theme) => ({
-  customInputLabel: {
-    '& legend': {
-      visibility: 'visible',
-    },
-  },
-  // inputBox: {
-  //   minHeight: '46px',
-  //   zIndex: '999',
-  //   border: '1px solid #5E5E5E',
-  //   borderRadius: '16px',
-  //   boxSizing: 'border-box',
-  //   margin: '2px 18px 10px 18px',
-  // },
-  inputBox: {
-    minHeight: '56px',
-    // borderRadius: theme.spacing(2),
-    backgroundColor: '#282828',
-    zIndex: '999',
-    // width: '100%',
-    borderRadius: '16px',
-    boxSizing: 'border-box',
-    // margin: '2px 18px 10px 18px',
-    width: '100%',
-    marginBottom: '16px',
-  },
-  inputWrapper: {
-    paddingLeft: '18px',
-    paddingRight: '18px',
-    width: 'auto',
-  },
-}));
-
 const AddressBook = () => {
   const [group, setGroup] = useState<Array<Contact>>([]);
   const grouped = _.groupBy(group, (contact) => contact.contact_name[0]);
 
   const history = useHistory();
-  const classes = useStyles();
   const wallet = useWallet();
 
   const [name, setName] = useState('');
@@ -221,12 +186,26 @@ const AddressBook = () => {
             }}
           />
         </Box>
-        <div className={classes.inputWrapper}>
+        <Box
+          sx={{
+            paddingLeft: '18px',
+            paddingRight: '18px',
+            width: 'auto',
+          }}
+        >
           <Input
             type="search"
             value={name}
             onChange={filter}
-            className={classes.inputBox}
+            sx={{
+              minHeight: '56px',
+              backgroundColor: '#282828',
+              zIndex: '999',
+              borderRadius: '16px',
+              boxSizing: 'border-box',
+              width: '100%',
+              marginBottom: '16px',
+            }}
             placeholder={chrome.i18n.getMessage('Search')}
             autoFocus
             disableUnderline
@@ -236,7 +215,7 @@ const AddressBook = () => {
               </InputAdornment>
             }
           />
-        </div>
+        </Box>
 
         <AddOrEditAddress
           isAddAddressOpen={isAddAddressOpen}

--- a/src/ui/views/Setting/Backups/index.tsx
+++ b/src/ui/views/Setting/Backups/index.tsx
@@ -1,5 +1,4 @@
 import { Box, Typography, IconButton, Button } from '@mui/material';
-import { makeStyles } from '@mui/styles';
 import React, { useState, useEffect, useCallback } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
@@ -11,53 +10,6 @@ import IconGoogleDrive from '@/ui/components/iconfont/IconGoogleDrive';
 import { LLDeleteBackupPopup } from '@/ui/components/LLDeleteBackupPopup';
 import { useWallet } from 'ui/utils';
 
-const useStyles = makeStyles(() => ({
-  arrowback: {
-    borderRadius: '100%',
-    margin: '8px',
-  },
-  iconbox: {
-    position: 'sticky',
-    top: 0,
-    // width: '100%',
-    backgroundColor: '#121212',
-    margin: 0,
-    padding: 0,
-  },
-  developerTitle: {
-    zIndex: 20,
-    textAlign: 'center',
-    top: 0,
-    position: 'sticky',
-  },
-  developerBox: {
-    width: 'auto',
-    height: 'auto',
-    margin: '20px 20px',
-    backgroundColor: '#282828',
-    padding: '20px 20px',
-    display: 'flex',
-    flexDirection: 'row',
-    borderRadius: '16px',
-    alignContent: 'space-between',
-    alignItems: 'center',
-    gap: '8px',
-  },
-  radioBox: {
-    width: '90%',
-    borderRadius: '16px',
-    backgroundColor: '#282828',
-    margin: '20px auto',
-    // padding: '10px 24px',
-  },
-  checkboxRow: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignContent: 'space-between',
-    justifyContent: 'space-between',
-    padding: '20px 24px',
-  },
-}));
 interface BackupsState {
   password?: string;
 }
@@ -69,7 +21,6 @@ const ManageBackups = () => {
   const location = useLocation<BackupsState>();
   const history = useHistory();
   const wallet = useWallet();
-  const classes = useStyles();
   const [hasPermission, setHasPermission] = useState(false);
   const [hasBackup, setHasBackup] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -163,7 +114,21 @@ const ManageBackups = () => {
   return (
     <div className="page" style={{ display: 'flex', flexDirection: 'column' }}>
       <LLHeader title={chrome.i18n.getMessage('Manage__Backups')} help={false} />
-      <Box className={classes.developerBox}>
+      <Box
+        sx={{
+          width: 'auto',
+          height: 'auto',
+          margin: '20px 20px',
+          backgroundColor: '#282828',
+          padding: '20px 20px',
+          display: 'flex',
+          flexDirection: 'row',
+          borderRadius: '16px',
+          alignContent: 'space-between',
+          alignItems: 'center',
+          gap: '8px',
+        }}
+      >
         <IconGoogleDrive size={20} />
         <Typography variant="body1" color="neutral.contrastText" style={{ weight: 600 }}>
           {chrome.i18n.getMessage('Google__Drive')}

--- a/src/ui/views/Setting/Currency/index.tsx
+++ b/src/ui/views/Setting/Currency/index.tsx
@@ -1,5 +1,4 @@
 import { Box, Typography, List, ListItemButton, ListItem, CircularProgress } from '@mui/material';
-import { makeStyles } from '@mui/styles';
 import React, { useCallback } from 'react';
 
 import { consoleError } from '@/shared/utils/console-log';
@@ -7,54 +6,7 @@ import { LLHeader } from '@/ui/components';
 import { useCurrency, useSupportedCurrencies } from '@/ui/hooks/preference-hooks';
 import { useWallet, useWalletLoaded } from '@/ui/utils';
 
-const useStyles = makeStyles(() => ({
-  arrowback: {
-    borderRadius: '100%',
-    margin: '8px',
-  },
-  currencyBox: {
-    width: '90%',
-    margin: '10px auto',
-    backgroundColor: '#282828',
-    padding: '20px 24px',
-    display: 'flex',
-    flexDirection: 'column',
-    borderRadius: '16px',
-    gap: '8px',
-  },
-  list: {
-    width: '100%',
-    borderRadius: '12px',
-    overflow: 'hidden',
-    backgroundColor: '#1A1A1A',
-    '&:hover': {
-      backgroundColor: '#1A1A1A',
-    },
-  },
-  listItem: {
-    height: '48px',
-    width: '100%',
-    overflow: 'hidden',
-    '&:hover': {
-      backgroundColor: '#333333',
-    },
-    '&.selected': {
-      backgroundColor: '#333333',
-    },
-  },
-  listItemButton: {
-    width: '100%',
-    height: '100%',
-    overflow: 'hidden',
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    padding: '0 16px',
-  },
-}));
-
 const CurrencySettings = () => {
-  const classes = useStyles();
   const walletLoaded = useWalletLoaded();
   const wallet = useWallet();
   const currentCurrency = useCurrency();
@@ -86,23 +38,64 @@ const CurrencySettings = () => {
   return (
     <div className="page">
       <LLHeader title={chrome.i18n.getMessage('Display__Currency')} help={false} />
-      <Box className={classes.currencyBox}>
+      <Box
+        sx={{
+          width: '90%',
+          margin: '10px auto',
+          backgroundColor: '#282828',
+          padding: '20px 24px',
+          display: 'flex',
+          flexDirection: 'column',
+          borderRadius: '16px',
+          gap: '8px',
+        }}
+      >
         <Typography variant="body1" color="neutral.contrastText" style={{ fontWeight: 600 }}>
           {chrome.i18n.getMessage('Select__Currency')}
         </Typography>
         <Typography variant="body2" color="text.secondary">
           {chrome.i18n.getMessage('Currency__Description')}
         </Typography>
-        <List className={classes.list}>
+        <List
+          sx={{
+            width: '100%',
+            borderRadius: '12px',
+            overflow: 'hidden',
+            backgroundColor: '#1A1A1A',
+            '&:hover': {
+              backgroundColor: '#1A1A1A',
+            },
+          }}
+        >
           {supportedCurrencies?.map((curr) => (
             <ListItem
               key={curr.code}
               component="div"
               onClick={() => handleCurrencyChange(curr.code)}
-              className={`${classes.listItem} ${curr.code === currentCurrency?.code ? 'selected' : ''}`}
+              sx={{
+                height: '48px',
+                width: '100%',
+                overflow: 'hidden',
+                '&:hover': {
+                  backgroundColor: '#333333',
+                },
+                ...(curr.code === currentCurrency?.code && {
+                  backgroundColor: '#333333',
+                }),
+              }}
               disablePadding
             >
-              <ListItemButton className={classes.listItemButton}>
+              <ListItemButton
+                sx={{
+                  width: '100%',
+                  height: '100%',
+                  overflow: 'hidden',
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  padding: '0 16px',
+                }}
+              >
                 <Typography color="neutral.contrastText">
                   {curr.code} ({curr.symbol}) {curr.name}
                 </Typography>

--- a/src/ui/views/Setting/DeveloperMode/DeveloperMode.tsx
+++ b/src/ui/views/Setting/DeveloperMode/DeveloperMode.tsx
@@ -10,83 +10,12 @@ import {
   FormControlLabel,
   Fade,
 } from '@mui/material';
-import { makeStyles } from '@mui/styles';
 import { styled } from '@mui/system';
 import React, { useState, useEffect, useCallback } from 'react';
 
 import { storage } from '@/background/webapi';
 import { LLHeader } from '@/ui/components';
 import { useWallet } from 'ui/utils';
-
-const useStyles = makeStyles(() => ({
-  arrowback: {
-    borderRadius: '100%',
-    margin: '8px',
-  },
-  iconbox: {
-    position: 'sticky',
-    top: 0,
-    // width: '100%',
-    backgroundColor: '#121212',
-    margin: 0,
-    padding: 0,
-  },
-  developerTitle: {
-    zIndex: 20,
-    textAlign: 'center',
-    top: 0,
-    position: 'sticky',
-  },
-  developerBox: {
-    width: 'auto',
-    height: 'auto',
-    margin: '10px 20px',
-    backgroundColor: '#282828',
-    padding: '24px 20px',
-    display: 'flex',
-    flexDirection: 'row',
-    borderRadius: '16px',
-    alignContent: 'space-between',
-  },
-
-  gasBox: {
-    width: '90%',
-    margin: '10px auto',
-    backgroundColor: '#282828',
-    padding: '20px 24px',
-    display: 'flex',
-    flexDirection: 'row',
-    borderRadius: '16px',
-    alignContent: 'space-between',
-    gap: '8px',
-  },
-
-  radioBox: {
-    width: '90%',
-    borderRadius: '16px',
-    backgroundColor: '#282828',
-    margin: '20px auto',
-    // padding: '10px 24px',
-  },
-  checkboxRow: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignContent: 'space-between',
-    justifyContent: 'space-between',
-    padding: '20px 24px',
-    alignItems: 'center',
-  },
-  modeSelection: {
-    width: '100%',
-    height: '100%',
-    padding: 0,
-    margin: 0,
-    borderRadius: '16px',
-    '&:hover': {
-      backgroundColor: '#282828',
-    },
-  },
-}));
 
 const orange = {
   500: '#41CC5D',
@@ -168,7 +97,6 @@ const Root = styled('span')(
 
 const DeveloperMode = () => {
   const usewallet = useWallet();
-  const classes = useStyles();
   const [developerModeOn, setDeveloperModeOn] = useState(false);
   const [emulatorFeatureEnabled, setEmulatorFeatureEnabled] = useState(false);
   const [emulatorModeOn, setEmulatorModeOn] = useState(false);
@@ -243,7 +171,19 @@ const DeveloperMode = () => {
     <div className="page">
       <LLHeader title={chrome.i18n.getMessage('Developer__Settings')} help={false} />
 
-      <Box className={classes.developerBox}>
+      <Box
+        sx={{
+          width: 'auto',
+          height: 'auto',
+          margin: '10px 20px',
+          backgroundColor: '#282828',
+          padding: '24px 20px',
+          display: 'flex',
+          flexDirection: 'row',
+          borderRadius: '16px',
+          alignContent: 'space-between',
+        }}
+      >
         <Typography variant="body1" color="neutral.contrastText" style={{ weight: 600 }}>
           {chrome.i18n.getMessage('Developer__Mode')}
         </Typography>
@@ -260,7 +200,19 @@ const DeveloperMode = () => {
       <Fade in={developerModeOn}>
         <Box sx={{ pb: '20px' }}>
           {emulatorFeatureEnabled && (
-            <Box className={classes.developerBox}>
+            <Box
+              sx={{
+                width: 'auto',
+                height: 'auto',
+                margin: '10px 20px',
+                backgroundColor: '#282828',
+                padding: '24px 20px',
+                display: 'flex',
+                flexDirection: 'row',
+                borderRadius: '16px',
+                alignContent: 'space-between',
+              }}
+            >
               <Typography variant="body1" color="neutral.contrastText" style={{ weight: 600 }}>
                 {chrome.i18n.getMessage('Emulator_Mode')}
               </Typography>
@@ -285,12 +237,37 @@ const DeveloperMode = () => {
           >
             {chrome.i18n.getMessage('Switch__Network')}
           </Typography>
-          <Box className={classes.radioBox}>
+          <Box
+            sx={{
+              width: '90%',
+              borderRadius: '16px',
+              backgroundColor: '#282828',
+              margin: '20px auto',
+            }}
+          >
             <CardActionArea
-              className={classes.modeSelection}
+              sx={{
+                width: '100%',
+                height: '100%',
+                padding: 0,
+                margin: 0,
+                borderRadius: '16px',
+                '&:hover': {
+                  backgroundColor: '#282828',
+                },
+              }}
               onClick={() => switchNetwork('mainnet')}
             >
-              <Box className={classes.checkboxRow}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  alignContent: 'space-between',
+                  justifyContent: 'space-between',
+                  padding: '20px 24px',
+                  alignItems: 'center',
+                }}
+              >
                 <FormControlLabel
                   label={chrome.i18n.getMessage('Mainnet')}
                   control={
@@ -321,10 +298,28 @@ const DeveloperMode = () => {
             <Divider sx={{ width: '90%', margin: '0 auto' }} />
 
             <CardActionArea
-              className={classes.modeSelection}
+              sx={{
+                width: '100%',
+                height: '100%',
+                padding: 0,
+                margin: 0,
+                borderRadius: '16px',
+                '&:hover': {
+                  backgroundColor: '#282828',
+                },
+              }}
               onClick={() => switchNetwork('testnet')}
             >
-              <Box className={classes.checkboxRow}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  alignContent: 'space-between',
+                  justifyContent: 'space-between',
+                  padding: '20px 24px',
+                  alignItems: 'center',
+                }}
+              >
                 <FormControlLabel
                   label={chrome.i18n.getMessage('Testnet')}
                   control={
@@ -363,12 +358,37 @@ const DeveloperMode = () => {
           >
             {chrome.i18n.getMessage('Transaction__Monitor')}
           </Typography>
-          <Box className={classes.radioBox}>
+          <Box
+            sx={{
+              width: '90%',
+              borderRadius: '16px',
+              backgroundColor: '#282828',
+              margin: '20px auto',
+            }}
+          >
             <CardActionArea
-              className={classes.modeSelection}
+              sx={{
+                width: '100%',
+                height: '100%',
+                padding: 0,
+                margin: 0,
+                borderRadius: '16px',
+                '&:hover': {
+                  backgroundColor: '#282828',
+                },
+              }}
               onClick={() => switchMonitor('flowscan')}
             >
-              <Box className={classes.checkboxRow}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  alignContent: 'space-between',
+                  justifyContent: 'space-between',
+                  padding: '20px 24px',
+                  alignItems: 'center',
+                }}
+              >
                 <FormControlLabel
                   label="Flowscan"
                   control={
@@ -399,10 +419,28 @@ const DeveloperMode = () => {
             <Divider sx={{ width: '90%', margin: '0 auto' }} />
 
             <CardActionArea
-              className={classes.modeSelection}
+              sx={{
+                width: '100%',
+                height: '100%',
+                padding: 0,
+                margin: 0,
+                borderRadius: '16px',
+                '&:hover': {
+                  backgroundColor: '#282828',
+                },
+              }}
               onClick={() => switchMonitor('source')}
             >
-              <Box className={classes.checkboxRow}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  alignContent: 'space-between',
+                  justifyContent: 'space-between',
+                  padding: '20px 24px',
+                  alignItems: 'center',
+                }}
+              >
                 <FormControlLabel
                   label={chrome.i18n.getMessage('Flow__view__source')}
                   control={

--- a/src/ui/views/Setting/Linked/LinkedCollection.tsx
+++ b/src/ui/views/Setting/Linked/LinkedCollection.tsx
@@ -16,7 +16,6 @@ import {
   Tooltip,
 } from '@mui/material';
 import { StyledEngineProvider } from '@mui/material/styles';
-import { makeStyles } from '@mui/styles';
 import React, { useState, useEffect, useCallback } from 'react';
 import InfiniteScroll from 'react-infinite-scroll-component';
 import { useHistory, useParams, useLocation } from 'react-router-dom';
@@ -60,111 +59,6 @@ interface NFT {
   postMedia: PostMedia;
 }
 
-const useStyles = makeStyles(() => ({
-  title: {
-    fontSize: '22px',
-    color: '#F2F2F2',
-    lingHeight: '32px',
-    fontWeight: 600,
-    margin: '18px',
-  },
-  card: {
-    width: '185px',
-    height: '225px',
-    backgroundColor: '#1B1B1B',
-    padding: '0',
-    boxShadow: 'none',
-    margin: 0,
-    borderRadius: '8px',
-  },
-  cardNoHover: {
-    flex: '50%',
-    padding: '13px',
-    // height: '211px',
-    backgroundColor: 'inherit',
-    boxShadow: 'none',
-    margin: 0,
-    borderRadius: '8px',
-    display: 'inline-block',
-  },
-  actionarea: {
-    width: '100%',
-    height: '100%',
-    borderRadius: '8px',
-    padding: '13px',
-    '&:hover': {
-      color: '#282828',
-      backgroundColor: '#282828',
-    },
-  },
-  grid: {
-    width: '100%',
-    minHeight: '360px',
-    backgroundColor: '#1B1B1B',
-    borderRadius: '16px 16px 0 0',
-    padding: '10px 13px',
-    margin: 0,
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignContent: 'flex-start',
-    // marginLeft: 'auto'
-    marginBottom: '20px',
-    overflow: 'auto',
-  },
-  cardmedia: {
-    height: '159px',
-    width: '100%',
-    justifyContent: 'center',
-  },
-  media: {
-    maxWidth: '100%',
-    maxHeight: '100%',
-    borderRadius: '8px',
-    margin: '0 auto',
-  },
-  content: {
-    height: '40px',
-    padding: '5px 0',
-    backgroundColor: 'inherit',
-    borderRadius: '0 0 8px 8px',
-  },
-  nftname: {
-    color: '#E6E6E6',
-    fontSize: '14px',
-  },
-  nftprice: {
-    color: '#808080',
-    fontSize: '14px',
-  },
-  collectionCard: {
-    display: 'flex',
-    width: '100%',
-    height: '64px',
-    margin: '11px auto',
-    borderRadius: '16px',
-    boxShadow: 'none',
-  },
-  collectionImg: {
-    borderRadius: '12px',
-    width: '48px',
-    margin: '8px',
-  },
-  arrowback: {
-    borderRadius: '100%',
-    margin: '8px',
-  },
-  iconbox: {
-    position: 'sticky',
-    top: 0,
-    backgroundColor: '#121212',
-    width: '100%',
-    margin: 0,
-    padding: 0,
-    zIndex: 5,
-  },
-}));
-
 interface CollectionDetailState {
   collection: any;
   ownerAddress: any;
@@ -174,7 +68,6 @@ interface CollectionDetailState {
 const LinkedCollection = (props) => {
   const usewallet = useWallet();
 
-  const classes = useStyles();
   const location = useParams();
 
   const uselocation = useLocation<CollectionDetailState>();
@@ -287,8 +180,24 @@ const LinkedCollection = (props) => {
   return (
     <StyledEngineProvider injectFirst>
       <div className="page" id="scrollableDiv" style={{ overflow: 'auto' }}>
-        <Box className={classes.iconbox}>
-          <IconButton onClick={() => history.goBack()} className={classes.arrowback}>
+        <Box
+          sx={{
+            position: 'sticky',
+            top: 0,
+            backgroundColor: '#121212',
+            width: '100%',
+            margin: 0,
+            padding: 0,
+            zIndex: 5,
+          }}
+        >
+          <IconButton
+            onClick={() => history.goBack()}
+            sx={{
+              borderRadius: '100%',
+              margin: '8px',
+            }}
+          >
             <ArrowBackIcon sx={{ color: 'icon.navi' }} />
           </IconButton>
         </Box>
@@ -395,10 +304,44 @@ const LinkedCollection = (props) => {
             </Grid>
 
             {loading ? (
-              <Grid container className={classes.grid}>
+              <Grid
+                container
+                sx={{
+                  width: '100%',
+                  minHeight: '360px',
+                  backgroundColor: '#1B1B1B',
+                  borderRadius: '16px 16px 0 0',
+                  padding: '10px 13px',
+                  margin: 0,
+                  display: 'flex',
+                  flexDirection: 'row',
+                  justifyContent: 'center',
+                  alignContent: 'flex-start',
+                  marginBottom: '20px',
+                  overflow: 'auto',
+                }}
+              >
                 {[...Array(4).keys()].map((key) => (
-                  <Card className={classes.card} elevation={0} key={key}>
-                    <CardMedia className={classes.cardmedia}>
+                  <Card
+                    sx={{
+                      width: '185px',
+                      height: '225px',
+                      backgroundColor: '#1B1B1B',
+                      padding: '0',
+                      boxShadow: 'none',
+                      margin: 0,
+                      borderRadius: '8px',
+                    }}
+                    elevation={0}
+                    key={key}
+                  >
+                    <CardMedia
+                      sx={{
+                        height: '159px',
+                        width: '100%',
+                        justifyContent: 'center',
+                      }}
+                    >
                       <Skeleton
                         variant="rectangular"
                         width={150}
@@ -406,7 +349,14 @@ const LinkedCollection = (props) => {
                         sx={{ margin: '0 auto', borderRadius: '8px' }}
                       />
                     </CardMedia>
-                    <CardContent className={classes.content}>
+                    <CardContent
+                      sx={{
+                        height: '40px',
+                        padding: '5px 0',
+                        backgroundColor: 'inherit',
+                        borderRadius: '0 0 8px 8px',
+                      }}
+                    >
                       <Skeleton variant="text" width={150} sx={{ margin: '0 auto' }} />
                     </CardContent>
                   </Card>
@@ -425,10 +375,37 @@ const LinkedCollection = (props) => {
                     borderRadius: '16px 16px 0 0',
                   }}
                 >
-                  <Grid container className={classes.grid}>
+                  <Grid
+                    container
+                    sx={{
+                      width: '100%',
+                      minHeight: '360px',
+                      backgroundColor: '#1B1B1B',
+                      borderRadius: '16px 16px 0 0',
+                      padding: '10px 13px',
+                      margin: 0,
+                      display: 'flex',
+                      flexDirection: 'row',
+                      justifyContent: 'center',
+                      alignContent: 'flex-start',
+                      marginBottom: '20px',
+                      overflow: 'auto',
+                    }}
+                  >
                     {list && list.map(createGridCard)}
                     {list.length % 2 !== 0 && (
-                      <Card className={classes.cardNoHover} elevation={0} />
+                      <Card
+                        sx={{
+                          flex: '50%',
+                          padding: '13px',
+                          backgroundColor: 'inherit',
+                          boxShadow: 'none',
+                          margin: 0,
+                          borderRadius: '8px',
+                          display: 'inline-block',
+                        }}
+                        elevation={0}
+                      />
                     )}
                   </Grid>
                 </InfiniteScroll>
@@ -436,10 +413,44 @@ const LinkedCollection = (props) => {
             )}
           </>
         ) : (
-          <Grid container className={classes.grid}>
+          <Grid
+            container
+            sx={{
+              width: '100%',
+              minHeight: '360px',
+              backgroundColor: '#1B1B1B',
+              borderRadius: '16px 16px 0 0',
+              padding: '10px 13px',
+              margin: 0,
+              display: 'flex',
+              flexDirection: 'row',
+              justifyContent: 'center',
+              alignContent: 'flex-start',
+              marginBottom: '20px',
+              overflow: 'auto',
+            }}
+          >
             {[...Array(4).keys()].map((key) => (
-              <Card className={classes.card} elevation={0} key={key}>
-                <CardMedia className={classes.cardmedia}>
+              <Card
+                sx={{
+                  width: '185px',
+                  height: '225px',
+                  backgroundColor: '#1B1B1B',
+                  padding: '0',
+                  boxShadow: 'none',
+                  margin: 0,
+                  borderRadius: '8px',
+                }}
+                elevation={0}
+                key={key}
+              >
+                <CardMedia
+                  sx={{
+                    height: '159px',
+                    width: '100%',
+                    justifyContent: 'center',
+                  }}
+                >
                   <Skeleton
                     variant="rectangular"
                     width={150}
@@ -447,7 +458,14 @@ const LinkedCollection = (props) => {
                     sx={{ margin: '0 auto', borderRadius: '8px' }}
                   />
                 </CardMedia>
-                <CardContent className={classes.content}>
+                <CardContent
+                  sx={{
+                    height: '40px',
+                    padding: '5px 0',
+                    backgroundColor: 'inherit',
+                    borderRadius: '0 0 8px 8px',
+                  }}
+                >
                   <Skeleton variant="text" width={150} sx={{ margin: '0 auto' }} />
                 </CardContent>
               </Card>

--- a/src/ui/views/Setting/Linked/LinkedNftDetail.tsx
+++ b/src/ui/views/Setting/Linked/LinkedNftDetail.tsx
@@ -3,7 +3,6 @@ import ArrowForwardOutlinedIcon from '@mui/icons-material/ArrowForwardOutlined';
 import SaveAltIcon from '@mui/icons-material/SaveAlt';
 import { Typography, Container, Box, IconButton, Button, CardMedia } from '@mui/material';
 import { StyledEngineProvider } from '@mui/material/styles';
-import { makeStyles } from '@mui/styles';
 import { saveAs } from 'file-saver';
 import React, { useState, useEffect, useCallback } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
@@ -16,64 +15,6 @@ import SendIcon from 'ui/assets/svg/detailSend.svg';
 import { useWallet } from 'ui/utils';
 
 import MoveFromChild from '../../NFT/SendNFT/MoveFromChild';
-
-const useStyles = makeStyles(() => ({
-  pageContainer: {
-    height: '100%',
-    width: '100%',
-    overflowY: 'scroll',
-    justifyContent: 'space-between',
-    padding: 0,
-    margin: 0,
-    display: 'flex',
-    flexDirection: 'column',
-  },
-  detailContainer: {
-    width: '100%',
-    backgroundColor: '#282828',
-    borderRadius: '16px 16px 0 0',
-    padding: '18px',
-    margin: 0,
-  },
-  metadata: {
-    borderRadius: '12px',
-    border: '1px solid rgba(186, 186, 186, 0.4)',
-    padding: '6px 10px',
-    maxWidth: '360px',
-  },
-  mediabox: {
-    width: '100%',
-    // minHeight: '354px',
-    justifyContent: 'center',
-    backgroundColor: 'inherit',
-    flexGrow: 1,
-    paddingBottom: '10px',
-  },
-  media: {
-    width: '100%',
-    borderRadius: '8px',
-  },
-  arrowback: {
-    borderRadius: '100%',
-    margin: '8px',
-  },
-  iconbox: {
-    position: 'sticky',
-    top: 0,
-    width: '100%',
-    backgroundColor: '#121212',
-    margin: 0,
-    padding: 0,
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-  },
-  extendMore: {
-    borderRadius: '100%',
-    margin: '8px',
-    marginRight: 0,
-  },
-}));
 
 interface NFTDetailState {
   nft: any;
@@ -93,7 +34,6 @@ const LinkedNftDetail = () => {
     },
   };
 
-  const classes = useStyles();
   const location = useLocation();
   const history = useHistory();
   const usewallet = useWallet();
@@ -192,7 +132,14 @@ const LinkedNftDetail = () => {
 
   const MetaBox = (props) => {
     return (
-      <Box className={classes.metadata}>
+      <Box
+        sx={{
+          borderRadius: '12px',
+          border: '1px solid rgba(186, 186, 186, 0.4)',
+          padding: '6px 10px',
+          maxWidth: '360px',
+        }}
+      >
         <Typography color="neutral2.main" variant="caption" sx={{ textTransform: 'uppercase' }}>
           {props.name}
         </Typography>
@@ -246,7 +193,7 @@ const LinkedNftDetail = () => {
           (media.image ? (
             <img
               src={replaceIPFS(media.image)}
-              className={classes.media}
+              style={{ width: '100%', borderRadius: '8px' }}
               onLoad={() => setMediaLoading(true)}
               onError={({ currentTarget }) => {
                 currentTarget.onerror = null; // prevents looping
@@ -271,7 +218,7 @@ const LinkedNftDetail = () => {
                   borderRadius: '8px',
                 }}
               >
-                <source src={media.video} type="video/mp4" className={classes.media} />
+                <source src={media.video} type="video/mp4" />
               </video>
             </>
           ))}
@@ -282,7 +229,12 @@ const LinkedNftDetail = () => {
   const getMedia = () => {
     return (
       <>
-        {mediaLoading && <img src={replaceIPFS(media?.image || null)} className={classes.media} />}
+        {mediaLoading && (
+          <img
+            src={replaceIPFS(media?.image || null)}
+            style={{ width: '100%', borderRadius: '8px' }}
+          />
+        )}
         <video
           loop
           autoPlay
@@ -294,7 +246,7 @@ const LinkedNftDetail = () => {
           onLoadedData={() => setMediaLoading(false)}
           style={{ visibility: mediaLoading ? 'hidden' : 'visible', width: '100%' }}
         >
-          <source src={media?.video || undefined} type="video/mp4" className={classes.media} />
+          <source src={media?.video || undefined} type="video/mp4" />
         </video>
       </>
     );
@@ -306,8 +258,26 @@ const LinkedNftDetail = () => {
         className="page"
         style={{ display: 'flex', position: 'relative', flexDirection: 'column' }}
       >
-        <Box className={classes.iconbox}>
-          <IconButton onClick={() => history.goBack()} className={classes.arrowback}>
+        <Box
+          sx={{
+            position: 'sticky',
+            top: 0,
+            width: '100%',
+            backgroundColor: '#121212',
+            margin: 0,
+            padding: 0,
+            display: 'flex',
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+          }}
+        >
+          <IconButton
+            onClick={() => history.goBack()}
+            sx={{
+              borderRadius: '100%',
+              margin: '8px',
+            }}
+          >
             <ArrowBackIcon sx={{ color: 'icon.navi' }} />
           </IconButton>
           {/* {
@@ -336,7 +306,18 @@ const LinkedNftDetail = () => {
         </Box>
 
         {nftDetail && (
-          <Container className={classes.pageContainer} sx={{ width: '100%' }}>
+          <Container
+            sx={{
+              height: '100%',
+              width: '100%',
+              overflowY: 'scroll',
+              justifyContent: 'space-between',
+              padding: 0,
+              margin: 0,
+              display: 'flex',
+              flexDirection: 'column',
+            }}
+          >
             <Box
               sx={{
                 padding: '10px 18px',
@@ -347,7 +328,15 @@ const LinkedNftDetail = () => {
                 flexGrow: 1,
               }}
             >
-              <Box className={classes.mediabox}>
+              <Box
+                sx={{
+                  width: '100%',
+                  justifyContent: 'center',
+                  backgroundColor: 'inherit',
+                  flexGrow: 1,
+                  paddingBottom: '10px',
+                }}
+              >
                 {media && media?.video !== null ? getMedia() : getUri()}
               </Box>
               <Box
@@ -417,7 +406,15 @@ const LinkedNftDetail = () => {
               </Box>
             </Box>
 
-            <Container className={classes.detailContainer}>
+            <Container
+              sx={{
+                width: '100%',
+                backgroundColor: '#282828',
+                borderRadius: '16px 16px 0 0',
+                padding: '18px',
+                margin: 0,
+              }}
+            >
               <Box
                 sx={{
                   display: 'inline-flex',

--- a/src/ui/views/Setting/Linked/UnlinkAccount.tsx
+++ b/src/ui/views/Setting/Linked/UnlinkAccount.tsx
@@ -1,7 +1,6 @@
 import CloseIcon from '@mui/icons-material/Close';
 import { Box, Drawer, Grid, Typography, Stack, InputBase } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import { makeStyles } from '@mui/styles';
 import React, { useState, useEffect } from 'react';
 import { useForm, type FieldValues } from 'react-hook-form';
 import { useHistory } from 'react-router-dom';
@@ -12,43 +11,6 @@ import UnlinkSVG from 'ui/assets/svg/unlink.svg';
 import { useWallet } from 'ui/utils';
 
 import { LLPrimaryButton, LLSecondaryButton, LLSpinner } from '../../../components';
-
-const useStyles = makeStyles(() => ({
-  IconCheck: {
-    display: 'inline',
-    backgroundColor: '#00E075',
-    borderRadius: '20px',
-    width: '14px',
-    height: '14px',
-    padding: '3px',
-  },
-  normalLine: {
-    width: '104px',
-    height: '4px',
-    marginTop: '24px',
-    backgroundImage: 'linear-gradient(to left, #5F5F5F, #5A5A5A, #5F5F5F)',
-    backgroundSize: '100% 100%',
-  },
-  pulseLine: {
-    width: '104px',
-    height: '4px',
-    marginTop: '24px',
-    backgroundImage: 'linear-gradient(to left, #2ae245, #000, #2ae245)',
-    backgroundSize: '200% 100%',
-    animation: '$gradient 5s ease infinite',
-  },
-  '@keyframes gradient': {
-    '0%': {
-      backgroundPosition: '100% 0%',
-    },
-    '50%': {
-      backgroundPosition: '0% 0%',
-    },
-    '100%': {
-      backgroundPosition: '100% 0%',
-    },
-  },
-}));
 
 interface UnlinkAccountProps {
   isAddAddressOpen: boolean;
@@ -67,7 +29,6 @@ export interface AddressBookValues {
 
 const UnlinkAccount = (props: UnlinkAccountProps) => {
   const history = useHistory();
-  const classes = useStyles();
 
   const wallet = useWallet();
   const {
@@ -180,11 +141,6 @@ const UnlinkAccount = (props: UnlinkAccountProps) => {
                 </Typography>
               )}
             </Box>
-            {/* {isLoading ? (
-              <Box className={classes.pulseLine}></Box>
-            ) : (
-              <Box className={classes.normalLine}></Box>
-            )} */}
 
             <img src={UnlinkSVG} />
 

--- a/src/ui/views/Setting/Linked/index.tsx
+++ b/src/ui/views/Setting/Linked/index.tsx
@@ -6,7 +6,6 @@ import {
   ListItemButton,
   Box,
 } from '@mui/material';
-import { makeStyles } from '@mui/styles';
 import React from 'react';
 import { Link } from 'react-router-dom';
 
@@ -15,34 +14,7 @@ import IconEnd from '@/ui/components/iconfont/IconAVector11Stroke';
 import { useProfiles } from '@/ui/hooks/useProfileHook';
 import EmptyStateImage from 'ui/assets/image/search_user.png';
 
-const useStyles = makeStyles(() => ({
-  logoBox: {
-    display: 'flex',
-    flexDirection: 'column',
-    padding: '18px',
-    alignItems: 'center',
-  },
-  mediaBox: {
-    width: '65%',
-    margin: '72px auto 16px auto',
-    alignItems: 'center',
-  },
-  logo: {
-    width: '84px',
-    height: '84px',
-    margin: '0 auto',
-  },
-  iconsBox: {
-    width: '100%',
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-  },
-}));
-
 const Linked = () => {
-  const classes = useStyles();
-
   const { childAccounts } = useProfiles();
 
   return (
@@ -62,7 +34,14 @@ const Linked = () => {
         </Typography>
       )}
       {childAccounts && childAccounts.length > 0 ? (
-        <Box className={classes.logoBox}>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            padding: '18px',
+            alignItems: 'center',
+          }}
+        >
           {childAccounts.map((childAccount) => (
             <ListItem
               key={childAccount.address}

--- a/src/ui/views/Setting/Settingone.tsx
+++ b/src/ui/views/Setting/Settingone.tsx
@@ -2,28 +2,8 @@ import SearchIcon from '@mui/icons-material/Search';
 import { List, ListItemText, ListItem, ListSubheader, ListItemAvatar, Input } from '@mui/material';
 import Avatar from '@mui/material/Avatar';
 import InputAdornment from '@mui/material/InputAdornment';
-import { makeStyles } from '@mui/styles';
 import _ from 'lodash';
 import React, { useState } from 'react';
-
-const useStyles = makeStyles((theme) => ({
-  customInputLabel: {
-    '& legend': {
-      visibility: 'visible',
-    },
-  },
-  inputBox: {
-    width: '364px',
-    height: '32px',
-    padding: '16px,16px,0px,16px',
-    zIndex: '999',
-    // backgroundColor: '#E5E5E5',
-    border: '1px solid #5E5E5E',
-    borderRadius: '16px',
-    boxSizing: 'border-box',
-    margin: '17px 18px 16px 18px',
-  },
-}));
 
 const CONTACTS = [
   {
@@ -77,7 +57,6 @@ const Settingone = () => {
   const group = CONTACTS.sort((a, b) => a.name.localeCompare(b.name));
   const grouped = _.groupBy(group, (contact) => contact.name[0]);
 
-  const classes = useStyles();
   const [name, setName] = useState('');
   const [foundContacts, setFoundContacts] = useState(group);
 
@@ -102,7 +81,17 @@ const Settingone = () => {
         type="search"
         value={name}
         onChange={filter}
-        className={classes.inputBox}
+        sx={{
+          width: '364px',
+          height: '32px',
+          padding: '16px,16px,0px,16px',
+          zIndex: '999',
+          // backgroundColor: '#E5E5E5',
+          border: '1px solid #5E5E5E',
+          borderRadius: '16px',
+          boxSizing: 'border-box',
+          margin: '17px 18px 16px 18px',
+        }}
         placeholder={chrome.i18n.getMessage('Search')}
         autoFocus
         disableUnderline

--- a/src/ui/views/Setting/Wallet/RemoveWallet.tsx
+++ b/src/ui/views/Setting/Wallet/RemoveWallet.tsx
@@ -1,6 +1,5 @@
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { Typography, Box, IconButton, Skeleton, Button } from '@mui/material';
-import { makeStyles } from '@mui/styles';
 import React, { useState, useEffect, useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
 
@@ -12,78 +11,7 @@ import { openInternalPageInTab } from 'ui/utils/webapi';
 
 import reset from '../../../assets/svg/reset.svg';
 
-const useStyles = makeStyles(() => ({
-  arrowback: {
-    borderRadius: '100%',
-    margin: '8px',
-  },
-  iconbox: {
-    position: 'sticky',
-    top: 0,
-    width: '100%',
-    backgroundColor: '#121212',
-    margin: 0,
-    padding: 0,
-  },
-  developerTitle: {
-    zIndex: 20,
-    textAlign: 'center',
-    top: 0,
-    position: 'sticky',
-  },
-  developerBox: {
-    width: '90%',
-    height: '67px',
-    marginBottom: '10px',
-    backgroundColor: '#282828',
-    padding: '20px 24px',
-    display: 'flex',
-    flexDirection: 'row',
-    borderRadius: '16px',
-    alignContent: 'space-between',
-  },
-  itemButton: {
-    width: '90%',
-    height: '100%',
-    margin: '0 auto',
-    '&:hover': {
-      backgroundColor: '#282828',
-    },
-  },
-  titleBox: {
-    width: '90%',
-    margin: '20px auto',
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'center',
-  },
-  walletBox: {
-    width: '100%',
-    backgroundColor: '#282828',
-    py: '12px',
-    borderRadius: '16px',
-    padding: 0,
-    margin: '10px 0',
-  },
-  disclaimerBox: {
-    width: '90%',
-    magrinBottom: '10px',
-    border: '1px solid #4C4C4C',
-    borderRadius: '16px',
-    padding: '20px',
-  },
-  buttonBox: {
-    width: '90%',
-    margin: '20px auto',
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    gap: '18px',
-  },
-}));
-
 const RemoveWallet = ({ hideBackButton = false }) => {
-  const classes = useStyles();
   const history = useHistory();
 
   const restPass = () => {
@@ -144,19 +72,51 @@ const RemoveWallet = ({ hideBackButton = false }) => {
       style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
     >
       {!hideBackButton && (
-        <Box className={classes.iconbox}>
-          <IconButton onClick={history.goBack} className={classes.arrowback}>
+        <Box
+          sx={{
+            position: 'sticky',
+            top: 0,
+            width: '100%',
+            backgroundColor: '#121212',
+            margin: 0,
+            padding: 0,
+          }}
+        >
+          <IconButton
+            onClick={history.goBack}
+            sx={{
+              borderRadius: '100%',
+              margin: '8px',
+            }}
+          >
             <ArrowBackIcon sx={{ color: 'icon.navi' }} />
           </IconButton>
         </Box>
       )}
 
-      <Box className={classes.titleBox}>
+      <Box
+        sx={{
+          width: '90%',
+          margin: '20px auto',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+        }}
+      >
         <img src={reset} alt="reset" width="56px" style={{ margin: '5px auto' }} />
         <Typography variant="h6" component="div" sx={{ margin: '5px auto', textAlign: 'center' }}>
           {chrome.i18n.getMessage('Are__you__sure__you__want__to__reset__your__wallet')}
         </Typography>
-        <Box className={classes.walletBox}>
+        <Box
+          sx={{
+            width: '100%',
+            backgroundColor: '#282828',
+            py: '12px',
+            borderRadius: '16px',
+            padding: 0,
+            margin: '10px 0',
+          }}
+        >
           <div style={{ margin: '11px', padding: '0 60px', alignSelf: 'center' }}>
             {!isLoading && walletName ? (
               <Typography display="inline-block" color="primary" variant="body1">
@@ -177,7 +137,15 @@ const RemoveWallet = ({ hideBackButton = false }) => {
         </Box>
       </Box>
 
-      <Box className={classes.disclaimerBox}>
+      <Box
+        sx={{
+          width: '90%',
+          magrinBottom: '10px',
+          border: '1px solid #4C4C4C',
+          borderRadius: '16px',
+          padding: '20px',
+        }}
+      >
         <Typography color="text.secondary" sx={{ fontSize: '14px' }}>
           {chrome.i18n.getMessage(
             'Removing__the__wallet__from__Lilico__does__not__remove__the__wallet__from__Flow__blockchain'
@@ -185,7 +153,16 @@ const RemoveWallet = ({ hideBackButton = false }) => {
         </Typography>
       </Box>
       <Box sx={{ flexGrow: 1 }} />
-      <Box className={classes.buttonBox}>
+      <Box
+        sx={{
+          width: '90%',
+          margin: '20px auto',
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          gap: '18px',
+        }}
+      >
         <LLSecondaryButton
           label={chrome.i18n.getMessage('Cancel')}
           fullWidth

--- a/src/ui/views/Setting/Wallet/WalletDetail.tsx
+++ b/src/ui/views/Setting/Wallet/WalletDetail.tsx
@@ -14,7 +14,6 @@ import {
   CardMedia,
 } from '@mui/material';
 import LinearProgress from '@mui/material/LinearProgress';
-import { makeStyles } from '@mui/styles';
 import { styled } from '@mui/system';
 import React, { useState, useEffect, useCallback } from 'react';
 import { Link, useLocation } from 'react-router-dom';
@@ -37,105 +36,6 @@ import editEmoji from '../../../assets/svg/editEmoji.svg';
 
 import EditProfile from './EditProfile';
 
-const useStyles = makeStyles(() => ({
-  arrowback: {
-    borderRadius: '100%',
-    margin: '8px',
-  },
-  iconbox: {
-    position: 'sticky',
-    top: 0,
-    // width: '100%',
-    backgroundColor: '#121212',
-    margin: 0,
-    padding: 0,
-  },
-  developerTitle: {
-    zIndex: 20,
-    textAlign: 'center',
-    top: 0,
-    position: 'sticky',
-  },
-  anonymousBox: {
-    width: '90%',
-    // height: '67px',
-    margin: '10px auto',
-    backgroundColor: '#282828',
-    padding: '20px 24px',
-    display: 'flex',
-    flexDirection: 'row',
-    borderRadius: '16px',
-    alignContent: 'space-between',
-    gap: '8px',
-  },
-  radioBox: {
-    width: '90%',
-    borderRadius: '16px',
-    backgroundColor: '#282828',
-    margin: '20px auto',
-    // padding: '10px 24px',
-  },
-  checkboxRow: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignContent: 'space-between',
-    justifyContent: 'space-between',
-    padding: '20px 24px',
-  },
-  listItem: {
-    height: '66px',
-    width: '100%',
-    '&:hover': {
-      backgroundColor: '#282828',
-    },
-  },
-  itemButton: {
-    width: '90%',
-    height: '100%',
-    margin: '0 auto',
-    '&:hover': {
-      backgroundColor: '#282828',
-    },
-  },
-  list: {
-    // width: '90%',
-    borderRadius: '16px',
-    padding: '0 10px',
-    overflow: 'hidden',
-    backgroundColor: '#282828',
-    '&:hover': {
-      backgroundColor: '#282828',
-    },
-  },
-  noBorder: {
-    border: 'none',
-  },
-  walletname: {
-    width: '90%',
-    borderRadius: '16px',
-    padding: '20px',
-    margin: '20px auto',
-    backgroundColor: '#282828',
-    '&:hover': {
-      backgroundColor: '#282828',
-    },
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-  },
-  gasBox: {
-    // width: '90%',
-    margin: '10px auto',
-    backgroundColor: '#282828',
-    padding: '20px 24px',
-    display: 'flex',
-    flexDirection: 'row',
-    borderRadius: '16px',
-    alignContent: 'space-between',
-    gap: '8px',
-  },
-}));
-
 const orange = {
   500: '#41CC5D',
 };
@@ -153,7 +53,6 @@ const Root = styled('span')(
     display: inline-block;
     width: 40px;
     height: 20px;
-    // margin: 0;
     margin-left: auto;
     cursor: pointer;
 
@@ -234,7 +133,6 @@ function formatStorageInfo(used: number | undefined, capacity: number | undefine
 }
 
 const WalletDetail = () => {
-  const classes = useStyles();
   const wallet = useWallet();
   const location = useLocation();
   const address = new URLSearchParams(location.search).get('address') || '';
@@ -344,13 +242,41 @@ const WalletDetail = () => {
         }}
       >
         <Box>
-          <List className={classes.list} sx={{ margin: '8px auto 8px auto', pt: 0, pb: 0 }}>
+          <List
+            sx={{
+              borderRadius: '16px',
+              padding: '0 10px',
+              overflow: 'hidden',
+              backgroundColor: '#282828',
+              '&:hover': {
+                backgroundColor: '#282828',
+              },
+              margin: '8px auto 8px auto',
+              pt: 0,
+              pb: 0,
+            }}
+          >
             <ListItem
               disablePadding
-              className={classes.listItem}
+              sx={{
+                height: '66px',
+                width: '100%',
+                '&:hover': {
+                  backgroundColor: '#282828',
+                },
+              }}
               onClick={() => toggleEditProfile()}
             >
-              <ListItemButton className={classes.itemButton}>
+              <ListItemButton
+                sx={{
+                  width: '90%',
+                  height: '100%',
+                  margin: '0 auto',
+                  '&:hover': {
+                    backgroundColor: '#282828',
+                  },
+                }}
+              >
                 <Box
                   sx={{
                     display: 'flex',
@@ -390,15 +316,43 @@ const WalletDetail = () => {
           </List>
           {userWallet && !isValidEthereumAddress(userWallet.address) && (
             <>
-              <List className={classes.list} sx={{ margin: '8px auto 8px auto', pt: 0, pb: 0 }}>
+              <List
+                sx={{
+                  borderRadius: '16px',
+                  padding: '0 10px',
+                  overflow: 'hidden',
+                  backgroundColor: '#282828',
+                  '&:hover': {
+                    backgroundColor: '#282828',
+                  },
+                  margin: '8px auto 8px auto',
+                  pt: 0,
+                  pb: 0,
+                }}
+              >
                 <ListItem
                   button
                   component={Link}
                   to="/dashboard/nested/privatekeypassword"
                   disablePadding
-                  className={classes.listItem}
+                  sx={{
+                    height: '66px',
+                    width: '100%',
+                    '&:hover': {
+                      backgroundColor: '#282828',
+                    },
+                  }}
                 >
-                  <ListItemButton className={classes.itemButton}>
+                  <ListItemButton
+                    sx={{
+                      width: '90%',
+                      height: '100%',
+                      margin: '0 auto',
+                      '&:hover': {
+                        backgroundColor: '#282828',
+                      },
+                    }}
+                  >
                     <ListItemText primary={chrome.i18n.getMessage('Private__Key')} />
                     <ListItemIcon aria-label="end" sx={{ minWidth: '15px' }}>
                       <IconEnd size={12} />
@@ -413,9 +367,24 @@ const WalletDetail = () => {
                     component={Link}
                     to="/dashboard/nested/recoveryphrasepassword"
                     disablePadding
-                    className={classes.listItem}
+                    sx={{
+                      height: '66px',
+                      width: '100%',
+                      '&:hover': {
+                        backgroundColor: '#282828',
+                      },
+                    }}
                   >
-                    <ListItemButton className={classes.itemButton}>
+                    <ListItemButton
+                      sx={{
+                        width: '90%',
+                        height: '100%',
+                        margin: '0 auto',
+                        '&:hover': {
+                          backgroundColor: '#282828',
+                        },
+                      }}
+                    >
                       <ListItemText primary={chrome.i18n.getMessage('Recovery__Phrase')} />
                       <ListItemIcon aria-label="end" sx={{ minWidth: '15px' }}>
                         <IconEnd size={12} />
@@ -426,15 +395,43 @@ const WalletDetail = () => {
               </List>
 
               <Box>
-                <List className={classes.list} sx={{ margin: '8px auto 8px auto', pt: 0, pb: 0 }}>
+                <List
+                  sx={{
+                    borderRadius: '16px',
+                    padding: '0 10px',
+                    overflow: 'hidden',
+                    backgroundColor: '#282828',
+                    '&:hover': {
+                      backgroundColor: '#282828',
+                    },
+                    margin: '8px auto 8px auto',
+                    pt: 0,
+                    pb: 0,
+                  }}
+                >
                   <ListItem
                     button
                     component={Link}
                     to={`/dashboard/nested/keylist?address=${address}`}
                     disablePadding
-                    className={classes.listItem}
+                    sx={{
+                      height: '66px',
+                      width: '100%',
+                      '&:hover': {
+                        backgroundColor: '#282828',
+                      },
+                    }}
                   >
-                    <ListItemButton className={classes.itemButton}>
+                    <ListItemButton
+                      sx={{
+                        width: '90%',
+                        height: '100%',
+                        margin: '0 auto',
+                        '&:hover': {
+                          backgroundColor: '#282828',
+                        },
+                      }}
+                    >
                       <ListItemText primary={'Account Keys'} />
                       <ListItemIcon aria-label="end" sx={{ minWidth: '15px' }}>
                         <IconEnd size={12} />
@@ -444,7 +441,18 @@ const WalletDetail = () => {
                 </List>
               </Box>
 
-              <Box className={classes.gasBox}>
+              <Box
+                sx={{
+                  margin: '10px auto',
+                  backgroundColor: '#282828',
+                  padding: '20px 24px',
+                  display: 'flex',
+                  flexDirection: 'row',
+                  borderRadius: '16px',
+                  alignContent: 'space-between',
+                  gap: '8px',
+                }}
+              >
                 <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                   <Typography variant="body1" color="neutral.contrastText" style={{ weight: 600 }}>
                     {chrome.i18n.getMessage('Free__Gas__Fee')}
@@ -471,7 +479,18 @@ const WalletDetail = () => {
                 />
               </Box>
               {!!storageInfo /* TODO: remove this after the storage usage card is implemented */ && (
-                <Box className={classes.gasBox}>
+                <Box
+                  sx={{
+                    margin: '10px auto',
+                    backgroundColor: '#282828',
+                    padding: '20px 24px',
+                    display: 'flex',
+                    flexDirection: 'row',
+                    borderRadius: '16px',
+                    alignContent: 'space-between',
+                    gap: '8px',
+                  }}
+                >
                   <Box sx={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
                     <Typography
                       variant="body1"

--- a/src/ui/views/Setting/change-password/index.tsx
+++ b/src/ui/views/Setting/change-password/index.tsx
@@ -13,7 +13,6 @@ import {
   Typography,
 } from '@mui/material';
 import Box from '@mui/material/Box';
-import { makeStyles } from '@mui/styles';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
@@ -30,61 +29,7 @@ import { GoogleWarningDialog } from './google-warning';
 import { PasswordIndicator } from './password-indicator';
 import { ProfileBackupSelectionDialog } from './profile-backup-selection';
 
-const useStyles = makeStyles(() => ({
-  customInputLabel: {
-    '& legend': {
-      visibility: 'visible',
-    },
-  },
-  inputBox: {
-    width: '355px',
-    height: '48px',
-    padding: '18px',
-    marginLeft: '18px',
-    marginRight: '18px',
-    zIndex: '999',
-    border: '1px solid #4C4C4C',
-    borderRadius: '8px',
-    boxSizing: 'border-box',
-    '&.Mui-focused': {
-      border: '1px solid #FAFAFA',
-      boxShadow: '0px 8px 12px 4px rgba(76, 76, 76, 0.24)',
-    },
-  },
-  inputBox2: {
-    width: '355px',
-    height: '48px',
-    padding: '18px',
-    marginLeft: '18px',
-    marginRight: '18px',
-    zIndex: '999',
-    border: '1px solid #4C4C4C',
-    borderRadius: '8px',
-    boxSizing: 'border-box',
-    '&.Mui-focused': {
-      border: '1px solid #FAFAFA',
-      boxShadow: '0px 8px 12px 4px rgba(76, 76, 76, 0.24)',
-    },
-  },
-  inputBox3: {
-    width: '355px',
-    height: '48px',
-    padding: '18px',
-    marginLeft: '18px',
-    marginRight: '18px',
-    zIndex: '999',
-    border: '1px solid #4C4C4C',
-    borderRadius: '8px',
-    boxSizing: 'border-box',
-    '&.Mui-focused': {
-      border: '1px solid #FAFAFA',
-      boxShadow: '0px 8px 12px 4px rgba(76, 76, 76, 0.24)',
-    },
-  },
-}));
-
 const ChangePassword = () => {
-  const classes = useStyles();
   const wallet = useWallet();
   const [isCurrentPasswordVisible, setCurrentPasswordVisible] = useState(false);
   const [isPasswordVisible, setPasswordVisible] = useState(false);
@@ -365,13 +310,29 @@ const ChangePassword = () => {
               {chrome.i18n.getMessage('Current__Password')}
             </Typography>
             <Input
-              sx={{ fontSize: '12px', fontFamily: 'Inter', fontStyle: 'normal' }}
+              sx={{
+                fontSize: '12px',
+                fontFamily: 'Inter',
+                fontStyle: 'normal',
+                width: '355px',
+                height: '48px',
+                padding: '18px',
+                marginLeft: '18px',
+                marginRight: '18px',
+                zIndex: '999',
+                border: '1px solid #4C4C4C',
+                borderRadius: '8px',
+                boxSizing: 'border-box',
+                '&.Mui-focused': {
+                  border: '1px solid #FAFAFA',
+                  boxShadow: '0px 8px 12px 4px rgba(76, 76, 76, 0.24)',
+                },
+              }}
               id="pass"
               name="password"
               type={isCurrentPasswordVisible ? 'text' : 'password'}
               placeholder={chrome.i18n.getMessage('Enter__Current__Password')}
               value={confirmCurrentPassword}
-              className={classes.inputBox}
               fullWidth
               autoFocus
               disableUnderline
@@ -420,13 +381,25 @@ const ChangePassword = () => {
                 fontSize: '12px',
                 fontFamily: 'Inter',
                 fontStyle: 'normal',
+                width: '355px',
+                height: '48px',
+                padding: '18px',
+                marginLeft: '18px',
+                marginRight: '18px',
+                zIndex: '999',
+                border: '1px solid #4C4C4C',
+                borderRadius: '8px',
+                boxSizing: 'border-box',
+                '&.Mui-focused': {
+                  border: '1px solid #FAFAFA',
+                  boxShadow: '0px 8px 12px 4px rgba(76, 76, 76, 0.24)',
+                },
               }}
               id="pass1"
               type={isPasswordVisible ? 'text' : 'password'}
               name="password1"
               placeholder={chrome.i18n.getMessage('Enter__New__Password')}
               value={password}
-              className={classes.inputBox2}
               fullWidth
               disableUnderline
               autoComplete="new-password"
@@ -469,13 +442,25 @@ const ChangePassword = () => {
                 fontSize: '12px',
                 fontFamily: 'Inter',
                 fontStyle: 'normal',
+                width: '355px',
+                height: '48px',
+                padding: '18px',
+                marginLeft: '18px',
+                marginRight: '18px',
+                zIndex: '999',
+                border: '1px solid #4C4C4C',
+                borderRadius: '8px',
+                boxSizing: 'border-box',
+                '&.Mui-focused': {
+                  border: '1px solid #FAFAFA',
+                  boxShadow: '0px 8px 12px 4px rgba(76, 76, 76, 0.24)',
+                },
               }}
               id="pass2"
               type={isConfirmPasswordVisible ? 'text' : 'password'}
               name="password2"
               placeholder={chrome.i18n.getMessage('Confirm__Password')}
               value={confirmPassword}
-              className={classes.inputBox3}
               autoComplete="new-password"
               fullWidth
               disableUnderline

--- a/src/ui/views/Setting/privatekey/Privatekeypassword.tsx
+++ b/src/ui/views/Setting/privatekey/Privatekeypassword.tsx
@@ -1,6 +1,5 @@
 import { Typography, Button, Fade, Input, FormControl } from '@mui/material';
 import Box from '@mui/material/Box';
-import { makeStyles } from '@mui/styles';
 import React, { useCallback, useEffect, useState } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 
@@ -9,28 +8,6 @@ import CancelIcon from '@/ui/components/iconfont/IconClose';
 import SettingsPassword from '@/ui/components/SettingsPassword';
 import SlideRelative from '@/ui/components/SlideRelative';
 import { useWallet } from 'ui/utils';
-
-const useStyles = makeStyles(() => ({
-  customInputLabel: {
-    '& legend': {
-      visibility: 'visible',
-    },
-  },
-  inputBox: {
-    height: '64px',
-    padding: '16px',
-    // magrinBottom: '64px',
-    zIndex: '999',
-    backgroundColor: '#121212',
-    border: '2px solid #4C4C4C',
-    borderRadius: '12px',
-    boxSizing: 'border-box',
-    '&.Mui-focused': {
-      border: '2px solid #FAFAFA',
-      boxShadow: '0px 8px 12px 4px rgba(76, 76, 76, 0.24)',
-    },
-  },
-}));
 
 const PrivateKeyPassword = () => {
   return (

--- a/src/ui/views/Setting/recoveryphase/Recoveryphrasepassword.tsx
+++ b/src/ui/views/Setting/recoveryphase/Recoveryphrasepassword.tsx
@@ -1,6 +1,5 @@
 import { Input, FormControl, Typography, Button, Fade } from '@mui/material';
 import Box from '@mui/material/Box';
-import { makeStyles } from '@mui/styles';
 import React, { useCallback, useEffect, useState } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 
@@ -10,32 +9,9 @@ import CancelIcon from '@/ui/components/iconfont/IconClose';
 import SlideRelative from '@/ui/components/SlideRelative';
 import { useWallet } from 'ui/utils';
 
-const useStyles = makeStyles(() => ({
-  customInputLabel: {
-    '& legend': {
-      visibility: 'visible',
-    },
-  },
-  inputBox: {
-    height: '64px',
-    padding: '16px',
-    // magrinBottom: '64px',
-    zIndex: '999',
-    backgroundColor: '#121212',
-    border: '2px solid #4C4C4C',
-    borderRadius: '12px',
-    boxSizing: 'border-box',
-    '&.Mui-focused': {
-      border: '2px solid #FAFAFA',
-      boxShadow: '0px 8px 12px 4px rgba(76, 76, 76, 0.24)',
-    },
-  },
-}));
-
 const Recoveryphrasepassword = () => {
   const history = useHistory();
   const wallet = useWallet();
-  const classes = useStyles();
   const [confirmPassword, setConfirmPassword] = useState(DEFAULT_PASSWORD);
   const [isMatch, setMatch] = useState(false);
 
@@ -121,7 +97,20 @@ const Recoveryphrasepassword = () => {
           <Input
             id="textfield"
             type="password"
-            className={classes.inputBox}
+            sx={{
+              height: '64px',
+              padding: '16px',
+              // magrinBottom: '64px',
+              zIndex: '999',
+              backgroundColor: '#121212',
+              border: '2px solid #4C4C4C',
+              borderRadius: '12px',
+              boxSizing: 'border-box',
+              '&.Mui-focused': {
+                border: '2px solid #FAFAFA',
+                boxShadow: '0px 8px 12px 4px rgba(76, 76, 76, 0.24)',
+              },
+            }}
             placeholder={chrome.i18n.getMessage('Enter__Your__Password')}
             autoFocus
             fullWidth

--- a/src/ui/views/Unlock/index.tsx
+++ b/src/ui/views/Unlock/index.tsx
@@ -1,6 +1,5 @@
 // import { useTranslation } from 'react-i18next';
 import { Input, Typography, Box, FormControl, CircularProgress } from '@mui/material';
-import { makeStyles } from '@mui/styles';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
@@ -15,28 +14,6 @@ import { useWallet, useWalletLoaded } from '@/ui/utils';
 import { openInternalPageInTab } from '@/ui/utils/webapi';
 
 import './style.css';
-
-const useStyles = makeStyles(() => ({
-  customInputLabel: {
-    '& legend': {
-      visibility: 'visible',
-    },
-  },
-  inputBox: {
-    height: '64px',
-    padding: '16px',
-    magrinBottom: '64px',
-    zIndex: '999',
-    backgroundColor: '#282828',
-    border: '2px solid #4C4C4C',
-    borderRadius: '12px',
-    boxSizing: 'border-box',
-    '&.Mui-focused': {
-      border: '2px solid #FAFAFA',
-      boxShadow: '0px 8px 12px 4px rgba(76, 76, 76, 0.24)',
-    },
-  },
-}));
 
 const UsernameError: React.FC = () => (
   <Box display="flex" flexDirection="row" alignItems="center">
@@ -60,7 +37,6 @@ const Unlock = () => {
   const wallet = useWallet();
   const walletIsLoaded = useWalletLoaded();
   const history = useHistory();
-  const classes = useStyles();
   const inputEl = useRef<any>(null);
   // const { t } = useTranslation();
   const [showPasswordError, setShowPasswordError] = useState(false);
@@ -154,7 +130,20 @@ const Unlock = () => {
         <Input
           id="textfield"
           type="password"
-          className={classes.inputBox}
+          sx={{
+            height: '64px',
+            padding: '16px',
+            magrinBottom: '64px',
+            zIndex: '999',
+            backgroundColor: '#282828',
+            border: '2px solid #4C4C4C',
+            borderRadius: '12px',
+            boxSizing: 'border-box',
+            '&.Mui-focused': {
+              border: '2px solid #FAFAFA',
+              boxShadow: '0px 8px 12px 4px rgba(76, 76, 76, 0.24)',
+            },
+          }}
           placeholder={chrome.i18n.getMessage('Enter__Your__Password')}
           autoFocus
           fullWidth


### PR DESCRIPTION
Closes #935

MUI styling was migrated from `makeStyles` to the `sx` prop, aligning with MUI v6 recommendations for improved performance, simpler syntax, and better TypeScript support.

Changes include:
*   Removal of `makeStyles` imports and `useStyles` hooks from components.
*   Conversion of JSS-defined styles to inline `sx` props on corresponding MUI components.
*   Styles with theme dependencies were adapted to use the theme directly within `sx`.
*   Approximately 17 UI components were updated, including `EmptyStatus.tsx`, `Setting/About/About.tsx`, `Setting/Currency/index.tsx`, `Setting/Backups/index.tsx`, `views/Unlock/index.tsx`, and various files within `Setting/Linked` and `Setting/Wallet`.
*   A new branch, `935-mui-makestyles-to-sx-migration`, was created to adhere to pre-commit naming conventions.
*   Code formatting was standardized using Prettier and linting issues resolved with ESLint before committing.

The migration resulted in a net reduction of 215 lines of code, leading to a cleaner and more modern codebase.