### PR TITLE
1076-feature-mark-transactions-as-done-when-finalised-not-executed

### DIFF
--- a/src/background/controller/wallet.ts
+++ b/src/background/controller/wallet.ts
@@ -3065,6 +3065,7 @@ export class WalletController extends BaseController {
 
   pollTransferList = async (address: string, txHash: string, maxAttempts = 5) => {
     const network = await this.getNetwork();
+    const currency = (await this.getDisplayCurrency())?.code || 'USD';
     let attempts = 0;
     const poll = async () => {
       if (attempts >= maxAttempts) {
@@ -3082,12 +3083,8 @@ export class WalletController extends BaseController {
 
       const foundTx = newTransactions?.find((tx) => txHash.includes(tx.hash));
       if (foundTx && foundTx.indexed) {
-        // Send a message to the UI to update the transfer list
-        chrome.runtime.sendMessage({ msg: 'transferListUpdated' });
         // Refresh the coin list
-        triggerRefresh(
-          coinListKey(network, address, (await this.getDisplayCurrency())?.code || 'USD')
-        );
+        triggerRefresh(coinListKey(network, address, currency));
       } else {
         // All of the transactions have not been picked up by the indexer yet
         attempts++;
@@ -3110,21 +3107,15 @@ export class WalletController extends BaseController {
     }
     const address = (await this.getCurrentAddress()) || '0x';
     const network = await this.getNetwork();
+    const currency = (await this.getDisplayCurrency())?.code || 'USD';
     let txHash = txId;
     try {
-      chrome.storage.session.set({
-        transactionPending: { txId, network, date: new Date() },
-      });
-      eventBus.emit('transactionPending');
-      chrome.runtime.sendMessage({
-        msg: 'transactionPending',
-        network: network,
-      });
       transactionService.setPending(network, address, txId, icon, title);
-
+      const fclTx = fcl.tx(txId);
       // Listen to the transaction until it's sealed.
       // This will throw an error if there is an error with the transaction
-      const txStatusFinalized = await fcl.tx(txId).onceFinalized();
+      const txStatusFinalized = await fclTx.onceFinalized();
+
       // Update the pending transaction with the transaction status
       txHash = await transactionService.updatePending(network, address, txId, txStatusFinalized);
 
@@ -3168,27 +3159,25 @@ export class WalletController extends BaseController {
       // Wait for the transacton to be executed
       // Listen to the transaction until it's sealed.
       // This will throw an error if there is an error with the transaction
-      const txStatusExecuted = await fcl.tx(txId).onceExecuted();
+      const txStatusExecuted = await fclTx.onceExecuted();
+
       // Update the pending transaction with the transaction status
       txHash = await transactionService.updatePending(network, address, txId, txStatusExecuted);
-      // Refresh the coin list
-      triggerRefresh(
-        coinListKey(network, address, (await this.getDisplayCurrency())?.code || 'USD')
-      );
       // Refresh the account balance
       triggerRefresh(accountBalanceKey(network, address));
+      // Refresh the coin list
+      triggerRefresh(coinListKey(network, address, currency));
 
       // Wait for the transaction to be sealed
-      const txStatusSealed = await fcl.tx(txId).onceSealed();
+      const txStatusSealed = await fclTx.onceSealed();
+
       // Update the pending transaction with the transaction status
       txHash = await transactionService.updatePending(network, address, txId, txStatusSealed);
 
-      // Refresh the coin list
-      triggerRefresh(
-        coinListKey(network, address, (await this.getDisplayCurrency())?.code || 'USD')
-      );
-      // Refresh the account balance
+      // Refresh the account balance after sealed status - just to be sure
       triggerRefresh(accountBalanceKey(network, address));
+      // Refresh the coin list after sealed status - just to be sure
+      triggerRefresh(coinListKey(network, address, currency));
     } catch (err: unknown) {
       // An error has occurred while listening to the transaction
       let errorMessage = 'unknown error';
@@ -3229,15 +3218,6 @@ export class WalletController extends BaseController {
         errorCode,
       });
     } finally {
-      // Remove the pending transaction from the UI
-      await chrome.storage.session.remove('transactionPending');
-
-      // Message the UI that the transaction is done
-      eventBus.emit('transactionDone');
-      chrome.runtime.sendMessage({
-        msg: 'transactionDone',
-      });
-
       if (txHash) {
         // Start polling for transfer list updates
         await this.pollTransferList(address, txHash);

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -425,7 +425,6 @@ const extMessageHandler = (msg, sender, sendResponse) => {
       });
   }
   sendResponse({ status: 'ok' });
-  // return true
 };
 
 /**

--- a/src/background/service/coinList.ts
+++ b/src/background/service/coinList.ts
@@ -132,10 +132,10 @@ class CoinList {
     try {
       let tokens: ExtendedTokenInfo[] = [];
       if (isEvmAddress) {
-        const evmTokenInfo = await this.getEvmTokenInfo(network, address, currencyCode);
+        const evmTokenInfo = await this.loadEvmTokenInfo(network, address, currencyCode);
         tokens = await this.transformEvmTokenExtendedInfo(evmTokenInfo);
       } else {
-        const cadenceTokenInfo = await this.getCadenceTokenInfo(network, address, currencyCode);
+        const cadenceTokenInfo = await this.loadCadenceTokenInfo(network, address, currencyCode);
         tokens = await this.transformCadenceTokenExtendedInfo(cadenceTokenInfo);
       }
 

--- a/src/background/service/transaction.ts
+++ b/src/background/service/transaction.ts
@@ -186,6 +186,9 @@ class Transaction {
       const storeItemIndex = existingTxStore.list.findIndex((item) => item.hash.includes(txId));
       if (storeItemIndex !== -1) {
         existingTxStore.list[storeItemIndex] = txItem;
+        existingTxStore.pendingCount = existingTxStore.list.filter(
+          (item) => item.status === 'PENDING'
+        ).length;
         await setCachedData(transferListKey(network, address), existingTxStore);
       }
     }
@@ -297,7 +300,8 @@ class Transaction {
     this.setPendingList(network, address, existingPendingList);
     const transferListStore: TransferListStore = {
       count: data.total + existingPendingList.length,
-      pendingCount: existingPendingList.length,
+      // This is the number of transaction that are in progress
+      pendingCount: existingPendingList.filter((item) => item.status === 'PENDING').length,
       list: [...existingPendingList, ...txList],
     };
     await setCachedData(transferListKey(network, address, offset, limit), transferListStore);

--- a/src/background/service/transaction.ts
+++ b/src/background/service/transaction.ts
@@ -3,7 +3,6 @@ import type { TransactionStatus } from '@onflow/typedefs';
 import openapiService, { type FlowTransactionResponse } from '@/background/service/openapi';
 import { type TransferItem } from '@/shared/types/transaction-types';
 import { isValidEthereumAddress, isValidFlowAddress } from '@/shared/utils/address';
-import { getCachedData } from '@/shared/utils/cache-data-access';
 import {
   transferListKey,
   type TransferListStore,
@@ -127,8 +126,6 @@ class Transaction {
       existingTxStore.count = existingTxStore.count + 1;
       await setCachedData(transferListKey(network, address), existingTxStore);
     }
-    // Send a message to the UI to update the transfer list
-    chrome.runtime.sendMessage({ msg: 'transferListUpdated' });
   };
 
   updatePending = async (
@@ -192,9 +189,6 @@ class Transaction {
         await setCachedData(transferListKey(network, address), existingTxStore);
       }
     }
-
-    // Send a message to the UI to update the transfer list
-    chrome.runtime.sendMessage({ msg: 'transferListUpdated' });
 
     // Return the hash of the transaction
     return combinedTxHash;

--- a/src/background/service/userWallet.ts
+++ b/src/background/service/userWallet.ts
@@ -1638,6 +1638,7 @@ const initAccountLoaders = () => {
     async (network: string, addresses: string[]) => {
       // Load the balances for all addresses
       const balances = await loadAccountListBalance(network, addresses);
+
       // Convert to a record keyed by address
       const result: Record<string, string> = {};
       addresses.forEach((address, index) => {

--- a/src/content-script/index.ts
+++ b/src/content-script/index.ts
@@ -1,7 +1,6 @@
 import { nanoid } from 'nanoid';
 import { v4 as uuid } from 'uuid';
 
-import { consoleLog } from '@/shared/utils/console-log';
 import { Message } from '@/shared/utils/messaging';
 
 const channelName = nanoid();
@@ -17,11 +16,6 @@ const injectProviderScript = (isDefaultWallet: boolean) => {
   localStorage.setItem(`${channelPrefix}isDefaultWallet`, isDefaultWallet.toString());
   localStorage.setItem(`${channelPrefix}uuid`, uuid());
   localStorage.setItem(`${channelPrefix}extensionId`, extensionId);
-
-  consoleLog(
-    'injectProviderScript get channelName',
-    localStorage.getItem(`${channelPrefix}channelName`)
-  );
 
   const container = document.head || document.documentElement;
   const scriptElement = document.createElement('script');
@@ -129,8 +123,6 @@ const extMessageHandler = (msg, _sender) => {
       window.postMessage(JSON.parse(JSON.stringify(msg || {})), '*');
     }
   }
-
-  return true;
 };
 
 /**

--- a/src/ui/views/Approval/components/EthApproval/EthConnect/index.tsx
+++ b/src/ui/views/Approval/components/EthApproval/EthConnect/index.tsx
@@ -98,28 +98,6 @@ const EthConnect = ({ params: { icon, name, origin } }: ConnectProps) => {
       });
   };
 
-  const transactionDoneHandler = useCallback(
-    async (request) => {
-      if (request.msg === 'transactionDone') {
-        const mainWallet = await usewallet.getParentAddress();
-        if (!mainWallet) {
-          throw new Error('Main wallet is undefined');
-        }
-      }
-      return true;
-    },
-    [usewallet]
-  );
-
-  useEffect(() => {
-    // Handle listenting for transactionDone event
-    chrome.runtime.onMessage.addListener(transactionDoneHandler);
-
-    return () => {
-      chrome.runtime.onMessage.removeListener(transactionDoneHandler);
-    };
-  }, [transactionDoneHandler]);
-
   const handleCancel = () => {
     // This is called when the user clicks the cancel button
     // This cancels the connection to the dApp

--- a/src/ui/views/Dashboard/Header.tsx
+++ b/src/ui/views/Dashboard/Header.tsx
@@ -103,16 +103,19 @@ const Header = ({ _loading = false }) => {
     [usewallet, history]
   );
 
-  const [errorCode, setErrorCode] = useState(null);
+  const [errorCode, setErrorCode] = useState<number | null>(null);
 
-  const transactionHandler = (request) => {
+  const transactionHandler = (request: {
+    msg: string;
+    errorMessage: string;
+    errorCode: number;
+  }) => {
     // The header should handle transactionError events
     if (request.msg === 'transactionError') {
       consoleWarn('transactionError', request.errorMessage, request.errorCode);
       // The error message is not used anywhere else for now
       setErrorCode(request.errorCode);
     }
-    return true;
   };
 
   const checkAuthStatus = useCallback(async () => {

--- a/src/ui/views/NFT/SendNFT/MoveFromChild.tsx
+++ b/src/ui/views/NFT/SendNFT/MoveFromChild.tsx
@@ -140,7 +140,6 @@ const MoveFromChild = (props: SendNFTConfirmationProps) => {
       setErrorMessage(request.errorMessage);
       setErrorCode(request.errorCode);
     }
-    return true;
   }, []);
 
   useEffect(() => {
@@ -149,7 +148,7 @@ const MoveFromChild = (props: SendNFTConfirmationProps) => {
     return () => {
       chrome.runtime.onMessage.removeListener(transactionDoneHandler);
     };
-  }, [props.data.contact, transactionDoneHandler]);
+  }, [props?.data?.contact, transactionDoneHandler]);
 
   const getChildResp = useCallback(async () => {
     const walletList = [...mainAccountContact, ...childAccountsContacts, ...evmAccounts];

--- a/src/ui/views/NFT/SendNFT/MovefromParent.tsx
+++ b/src/ui/views/NFT/SendNFT/MovefromParent.tsx
@@ -139,7 +139,6 @@ const MovefromParent = (props: SendNFTConfirmationProps) => {
       setErrorMessage(request.errorMessage);
       setErrorCode(request.errorCode);
     }
-    return true;
   }, []);
 
   useEffect(() => {
@@ -148,7 +147,7 @@ const MovefromParent = (props: SendNFTConfirmationProps) => {
     return () => {
       chrome.runtime.onMessage.removeListener(transactionDoneHandler);
     };
-  }, [props.data.contact, transactionDoneHandler]);
+  }, [props?.data?.contact, transactionDoneHandler]);
 
   const getChildResp = useCallback(async () => {
     // Merge usewallet lists

--- a/src/ui/views/NFT/SendNFT/SendNFTConfirmation.tsx
+++ b/src/ui/views/NFT/SendNFT/SendNFTConfirmation.tsx
@@ -274,7 +274,6 @@ const SendNFTConfirmation = (props: SendNFTConfirmationProps) => {
       setErrorMessage(request.errorMessage);
       setErrorCode(request.errorCode);
     }
-    return true;
   }, []);
 
   useEffect(() => {

--- a/src/ui/views/NftEvm/SendNFT/MoveNftFromEvm.tsx
+++ b/src/ui/views/NftEvm/SendNFT/MoveNftFromEvm.tsx
@@ -128,13 +128,11 @@ const MoveNftFromEvm = (props: SendNFTConfirmationProps) => {
   };
 
   const transactionDoneHandler = useCallback((request) => {
-    // Handle error
     if (request.msg === 'transactionError') {
       setFailed(true);
       setErrorMessage(request.errorMessage);
       setErrorCode(request.errorCode);
     }
-    return true;
   }, []);
 
   useEffect(() => {

--- a/src/ui/views/NftEvm/SendNFT/SendNFTConfirmation.tsx
+++ b/src/ui/views/NftEvm/SendNFT/SendNFTConfirmation.tsx
@@ -179,7 +179,6 @@ const SendNFTConfirmation = (props: SendNFTConfirmationProps) => {
       setErrorMessage(request.errorMessage);
       setErrorCode(request.errorCode);
     }
-    return true;
   }, []);
 
   useEffect(() => {

--- a/src/ui/views/SendTo/TransferConfirmation.tsx
+++ b/src/ui/views/SendTo/TransferConfirmation.tsx
@@ -132,7 +132,6 @@ const TransferConfirmation = ({
       setErrorMessage(request.errorMessage);
       setErrorCode(request.errorCode);
     }
-    return true;
   }, []);
 
   useEffect(() => {

--- a/src/ui/views/Wallet/Coinlist.tsx
+++ b/src/ui/views/Wallet/Coinlist.tsx
@@ -11,12 +11,12 @@ import {
   Avatar,
 } from '@mui/material';
 import { Box } from '@mui/system';
-import React, { type ReactNode, useEffect, useState } from 'react';
+import React from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { type CoinItem } from '@/shared/types/coin-types';
 import { type ActiveAccountType } from '@/shared/types/wallet-types';
-import { formatLargeNumber } from '@/shared/utils/number';
+import { type ChildAccountFtStore } from '@/shared/utils/cache-data-keys';
 import { TokenBalance } from '@/ui/components/TokenLists/TokenBalance';
 import { useCurrency } from '@/ui/hooks/preference-hooks';
 import { useCoins } from '@/ui/hooks/useCoinHook';
@@ -76,7 +76,7 @@ const CoinList = ({
   isActive,
   activeAccountType,
 }: {
-  ableFt: any[];
+  ableFt: ChildAccountFtStore;
   isActive: boolean;
   activeAccountType: ActiveAccountType;
 }) => {
@@ -197,7 +197,7 @@ const CoinList = ({
             <Box sx={{ display: 'flex', gap: '3px' }}>
               {ableFt.some((item) => {
                 const parts = item.id.split('.');
-                return parts[2] && parts[2].includes(props.name);
+                return parts[2] && props.name && parts[2].includes(props.name);
               }) ||
               isActive ||
               props.id?.toLowerCase().includes('flowtoken') ? (


### PR DESCRIPTION


## Related Issue

Closes #1076

## Summary of Changes

- Corrected coinlist refresh to load from the api properly. This now refeshes balances properly after sending a transaction
- Removed unnecessary message passing to the UI for transaction updates in various services.
- Updated transaction handling logic to use a consistent currency code retrieval method.
- Cleaned up event listeners in UI components to prevent unhandled message errors.

I decided in the end to not redirect back to the dashboard instead of the activity list. It just looks like nothing is going on. I think we can do better with token sending to guess the balances prior to sending and potentially show the balance in italics while we're waiting for the balance to update.  This won't work for anything but token sending, but I think it would make it seem really fast to send tokens. I also think we can do better with the display of transaction status. A spinner just looks too much like something the user has to wait for. Do we actually need to show anything?

## Need Regression Testing

- [X] Yes
- [ ] No

## Risk Assessment

- [X] Low
- [ ] Medium
- [ ] High

## Additional Notes

<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)

<!-- Attach any screenshots that help explain your changes -->
