### PR TITLE
Used new script to get all child and evm accounts in one hit. Removed seperate cache keys for evm account and child accounts

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,12 @@
 onlyBuiltDependencies:
   - '@swc/core'
+  - '@tsparticles/engine'
+  - bufferutil
+  - electron
   - esbuild
+  - keccak
   - protobufjs
+  - secp256k1
+  - storybook-addon-remix-react-router
   - unrs-resolver
+  - utf-8-validate

--- a/src/shared/types/wallet-types.ts
+++ b/src/shared/types/wallet-types.ts
@@ -112,7 +112,7 @@ export type WalletAccount = {
   chain: number; // testnet: 545, mainnet: MAINNET_CHAIN_ID
   id: number;
   name: string;
-  icon: string;
+  icon: string; // either an emoji or a url
   color: string;
   balance?: string;
   nfts?: number;
@@ -120,7 +120,11 @@ export type WalletAccount = {
 export type WalletAccountWithBalance = WalletAccount & {
   balance: string;
 };
-export type MainAccount = WalletAccount & PublicKeyAccount;
+export type MainAccount = WalletAccount &
+  PublicKeyAccount & {
+    evmAccount?: WalletAccount;
+    childAccounts?: WalletAccount[];
+  };
 
 export type MainAccountBalance = {
   address: string;

--- a/src/shared/utils/cache-data-keys.ts
+++ b/src/shared/utils/cache-data-keys.ts
@@ -142,29 +142,6 @@ export type PendingAccountCreationTransactionsStore = string[];
  * --------------------------------------------------------------------
  */
 
-// Child Accounts - the child accounts of a given main account on a given network
-export const childAccountsKey = (network: string, mainAccountAddress: string) =>
-  `child-accounts-${network}-${mainAccountAddress}`;
-export const childAccountsRefreshRegex = refreshKey(childAccountsKey);
-
-export type ChildAccountStore = WalletAccount[];
-
-export const getCachedChildAccounts = async (network: string, mainAccountAddress: string) => {
-  return getCachedData<ChildAccountStore>(childAccountsKey(network, mainAccountAddress));
-};
-
-// EVM Account - the EVM account of a given main account on a given network
-export const evmAccountKey = (network: string, mainAccountAddress: string) =>
-  `evm-account-${network}-${mainAccountAddress}`;
-
-export const evmAccountRefreshRegex = refreshKey(evmAccountKey);
-
-export type EvmAccountStore = WalletAccount;
-
-export const getCachedEvmAccount = async (network: string, mainAccountAddress: string) => {
-  return getCachedData<EvmAccountStore>(evmAccountKey(network, mainAccountAddress));
-};
-
 export const accountBalanceKey = (network: string, address: string) =>
   `account-balance-${network}-${address}`;
 export const accountBalanceRefreshRegex = refreshKey(accountBalanceKey);

--- a/src/shared/utils/user-data-access.ts
+++ b/src/shared/utils/user-data-access.ts
@@ -20,6 +20,15 @@ export const setUserData = async <T>(key: string, data: T) => {
 };
 
 /**
+ * Set user data in local storage
+ * @param key - The key to set the data to
+ * @param data - The data to set
+ */
+export const removeUserData = async (key: string) => {
+  await storage.remove(key);
+};
+
+/**
  * Internal function to call the update callback
  * @param key - The key to listen for
  * @param updateCallback - The callback to call when the data is updated

--- a/src/ui/components/account/account-listing.tsx
+++ b/src/ui/components/account/account-listing.tsx
@@ -1,9 +1,8 @@
 import { Box, Typography } from '@mui/material';
 import React from 'react';
 
-import { type WalletAccount } from '@/shared/types/wallet-types';
+import { type MainAccount, type WalletAccount } from '@/shared/types/wallet-types';
 import { isValidEthereumAddress } from '@/shared/utils/address';
-import { useChildAccounts, useEvmAccount } from '@/ui/hooks/use-account-hooks';
 import { useProfiles } from '@/ui/hooks/useProfileHook';
 import { COLOR_DARKMODE_TEXT_PRIMARY_80_FFFFFF80 } from '@/ui/style/color';
 
@@ -12,7 +11,7 @@ import { EnableEvmAccountCard } from './enable-evm-account-card';
 
 type AccountHierarchyProps = {
   network?: string;
-  account?: WalletAccount;
+  account?: MainAccount;
   activeAccount?: WalletAccount;
   onAccountClick?: (address: string, parentAddress?: string) => void;
   onAccountClickSecondary?: (address: string, parentAddress?: string) => void;
@@ -26,8 +25,8 @@ const AccountHierarchy = ({
   onAccountClickSecondary,
   secondaryIcon,
 }: AccountHierarchyProps) => {
-  const childAccounts = useChildAccounts(network, account?.address);
-  const evmAccount = useEvmAccount(network, account?.address);
+  const childAccounts = account?.childAccounts;
+  const evmAccount = account?.evmAccount;
   const loading = network === undefined || account === undefined;
   if (loading) {
     return (
@@ -110,9 +109,9 @@ const AccountHierarchy = ({
 
 type AccountListingProps = {
   network?: string;
-  accountList?: WalletAccount[];
+  accountList?: MainAccount[];
   activeAccount?: WalletAccount;
-  activeParentAccount?: WalletAccount;
+  activeParentAccount?: MainAccount;
   onAccountClick?: (address: string, parentAddress?: string) => void;
   onAccountClickSecondary?: (address: string, parentAddress?: string) => void;
   onEnableEvmClick?: (parentAddress: string) => void;
@@ -132,12 +131,7 @@ export const AccountListing = ({
   showActiveAccount = false,
 }: AccountListingProps) => {
   // Get the EVM account for the active account provided it's a main account
-  const evmAccount = useEvmAccount(
-    network,
-    activeParentAccount === undefined || activeAccount?.address === activeParentAccount?.address
-      ? activeAccount?.address
-      : undefined
-  );
+  const evmAccount = activeParentAccount?.evmAccount;
   // Check if the EVM account is not valid
   const noEvmAccount = evmAccount && !isValidEthereumAddress(evmAccount.address);
   //const pendingAccountTransactions = [];

--- a/src/ui/components/account/stories/account-listing.stories.tsx
+++ b/src/ui/components/account/stories/account-listing.stories.tsx
@@ -222,7 +222,6 @@ export const Active: Story = {
     accountList: [
       {
         ...mainWalletAccount,
-        evmAccount: evmWalletAccount,
         childAccounts: [childWallet1, childWallet2],
       },
     ],
@@ -252,7 +251,7 @@ export const EVMActive: Story = {
       {
         ...mainWalletAccount,
         evmAccount: evmWalletAccount,
-        childAccounts: [childWallet1, childWallet2],
+        childAccounts: [childWallet2],
       },
     ],
     activeAccount: evmWalletAccount,
@@ -281,7 +280,7 @@ export const NoEVM: Story = {
     accountList: [
       {
         ...mainWalletAccount,
-        evmAccount: evmWalletAccount,
+        evmAccount: noEvmWalletAccount,
         childAccounts: [childWallet1, childWallet2],
       },
     ],
@@ -328,8 +327,8 @@ export const PendingAccountTransaction: Story = {
     accountList: [
       {
         ...mainWalletAccount,
-        evmAccount: evmWalletAccount,
-        childAccounts: [childWallet1, childWallet2],
+        evmAccount: noEvmWalletAccount,
+        childAccounts: [childWallet2],
       },
     ],
     activeAccount: mainWalletAccount,
@@ -361,7 +360,7 @@ export const MultiplePendingAccountTransaction: Story = {
     accountList: [
       {
         ...mainWalletAccount,
-        evmAccount: evmWalletAccount,
+        evmAccount: evmWalletAccount2,
         childAccounts: [childWallet1, childWallet2],
       },
     ],

--- a/src/ui/components/account/stories/account-listing.stories.tsx
+++ b/src/ui/components/account/stories/account-listing.stories.tsx
@@ -6,12 +6,8 @@ import emojisJson from '@/background/utils/emoji.json';
 const { emojis } = emojisJson as { emojis: Emoji[] };
 import { MAINNET_CHAIN_ID } from '@/shared/types/network-types';
 import { type NFTCollections } from '@/shared/types/nft-types';
-import { type Emoji, type WalletAccount } from '@/shared/types/wallet-types';
+import { type MainAccount, type Emoji, type WalletAccount } from '@/shared/types/wallet-types';
 import { AccountListing } from '@/ui/components/account/account-listing';
-import {
-  useChildAccounts as importedMockUseChildAccounts, // Aliased import from the mock file
-  useEvmAccount as importedMockUseEvmAccount, // Aliased import from the mock file
-} from '@/ui/hooks/use-account-hooks.mock';
 import {
   useNftCatalogCollections as importedMockUseNftCatalogCollections, // Aliased import from the mock file
 } from '@/ui/hooks/useNftHook.mock';
@@ -20,7 +16,7 @@ import {
   useProfiles as importedMockUseProfiles,
 } from '@/ui/hooks/useProfileHook.mock';
 
-const mainWalletAccount: WalletAccount = {
+const mainWalletAccount: MainAccount = {
   name: emojis[2].name,
   icon: emojis[2].emoji,
   color: emojis[2].bgcolor,
@@ -29,8 +25,15 @@ const mainWalletAccount: WalletAccount = {
   id: 1,
   balance: '550.66005012',
   nfts: 12,
+  publicKey: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  keyIndex: 0,
+  weight: 1000,
+  signAlgo: 0,
+  signAlgoString: 'ECDSA',
+  hashAlgo: 0,
+  hashAlgoString: 'SHA256',
 };
-const mainWalletAccount2: WalletAccount = {
+const mainWalletAccount2: MainAccount = {
   name: emojis[3].name,
   icon: emojis[3].emoji,
   color: emojis[3].bgcolor,
@@ -39,6 +42,13 @@ const mainWalletAccount2: WalletAccount = {
   id: 1, // Differentiate ID if it matters for keying or logic
   balance: '0.00000077',
   nfts: 4,
+  publicKey: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  keyIndex: 0,
+  weight: 1000,
+  signAlgo: 0,
+  signAlgoString: 'ECDSA',
+  hashAlgo: 0,
+  hashAlgoString: 'SHA256',
 };
 
 const evmWalletAccount: WalletAccount = {
@@ -131,24 +141,10 @@ const meta: Meta<typeof AccountListing> = {
   decorators: [
     withRouter,
     (Story, context) => {
-      importedMockUseChildAccounts.mockReset();
-      importedMockUseEvmAccount.mockReset();
       importedMockUseNftCatalogCollections.mockReset();
       importedMockUseProfiles.mockReset();
       const { mockData } = context.parameters;
       if (mockData) {
-        importedMockUseEvmAccount.mockImplementation((_network, address) => {
-          if (typeof address === 'string' && mockData.evmAccounts) {
-            return mockData.evmAccounts[address];
-          }
-          return undefined;
-        });
-        importedMockUseChildAccounts.mockImplementation((_network, address) => {
-          if (typeof address === 'string' && mockData.childAccounts) {
-            return mockData.childAccounts[address] || [];
-          }
-          return [];
-        });
         importedMockUseNftCatalogCollections.mockImplementation(
           (network?: string, address?: string) => {
             if (typeof address === 'string' && mockData.nfts) {
@@ -181,7 +177,18 @@ type Story = StoryObj<typeof AccountListing>;
 export const Default: Story = {
   args: {
     network: 'mainnet',
-    accountList: [mainWalletAccount, mainWalletAccount2],
+    accountList: [
+      {
+        ...mainWalletAccount,
+        evmAccount: evmWalletAccount,
+        childAccounts: [childWallet1, childWallet2],
+      },
+      {
+        ...mainWalletAccount2,
+        evmAccount: evmWalletAccount2,
+        childAccounts: [],
+      },
+    ],
     activeAccount: undefined,
   },
   parameters: {
@@ -212,7 +219,13 @@ export const Default: Story = {
 export const Active: Story = {
   args: {
     network: 'mainnet',
-    accountList: [mainWalletAccount],
+    accountList: [
+      {
+        ...mainWalletAccount,
+        evmAccount: evmWalletAccount,
+        childAccounts: [childWallet1, childWallet2],
+      },
+    ],
     activeAccount: mainWalletAccount,
     activeParentAccount: mainWalletAccount, // not necessary if activeAccount is a main account
     showActiveAccount: true,
@@ -235,7 +248,13 @@ export const Active: Story = {
 export const EVMActive: Story = {
   args: {
     network: 'mainnet',
-    accountList: [mainWalletAccount],
+    accountList: [
+      {
+        ...mainWalletAccount,
+        evmAccount: evmWalletAccount,
+        childAccounts: [childWallet1, childWallet2],
+      },
+    ],
     activeAccount: evmWalletAccount,
     activeParentAccount: mainWalletAccount,
     showActiveAccount: true,
@@ -259,7 +278,13 @@ export const EVMActive: Story = {
 export const NoEVM: Story = {
   args: {
     network: 'mainnet',
-    accountList: [mainWalletAccount],
+    accountList: [
+      {
+        ...mainWalletAccount,
+        evmAccount: evmWalletAccount,
+        childAccounts: [childWallet1, childWallet2],
+      },
+    ],
     activeAccount: mainWalletAccount,
     activeParentAccount: mainWalletAccount,
     showActiveAccount: true,
@@ -300,7 +325,13 @@ export const LoadingActive: Story = {
 export const PendingAccountTransaction: Story = {
   args: {
     network: 'mainnet',
-    accountList: [mainWalletAccount],
+    accountList: [
+      {
+        ...mainWalletAccount,
+        evmAccount: evmWalletAccount,
+        childAccounts: [childWallet1, childWallet2],
+      },
+    ],
     activeAccount: mainWalletAccount,
     activeParentAccount: mainWalletAccount,
     showActiveAccount: true,
@@ -327,7 +358,13 @@ export const PendingAccountTransaction: Story = {
 export const MultiplePendingAccountTransaction: Story = {
   args: {
     network: 'mainnet',
-    accountList: [mainWalletAccount],
+    accountList: [
+      {
+        ...mainWalletAccount,
+        evmAccount: evmWalletAccount,
+        childAccounts: [childWallet1, childWallet2],
+      },
+    ],
     activeAccount: mainWalletAccount,
     activeParentAccount: mainWalletAccount,
     showActiveAccount: true,

--- a/src/ui/hooks/use-account-hooks.mock.ts
+++ b/src/ui/hooks/use-account-hooks.mock.ts
@@ -3,10 +3,6 @@ import { fn } from 'storybook/test';
 import * as actual from './use-account-hooks';
 
 // These are the mock function instances, exported with the names the component expects.
-export const useChildAccounts = fn(actual.useChildAccounts)
-  .mockName('useChildAccounts')
-  .mockReturnValue([]);
-export const useEvmAccount = fn(actual.useEvmAccount).mockName('useEvmAccount');
 export const useAccountBalance = fn(actual.useAccountBalance).mockName('useAccountBalance');
 export const usePendingAccountCreationTransactions = fn(
   actual.usePendingAccountCreationTransactions

--- a/src/ui/hooks/use-account-hooks.ts
+++ b/src/ui/hooks/use-account-hooks.ts
@@ -9,13 +9,10 @@ import {
 } from '@/shared/types/keyring-types';
 import {
   type MainAccount,
-  type WalletAccount,
   type PendingTransaction,
   getActiveAccountTypeForAddress,
 } from '@/shared/types/wallet-types';
 import {
-  childAccountsKey,
-  evmAccountKey,
   accountBalanceKey,
   mainAccountsKey,
   userInfoCachekey,
@@ -60,15 +57,6 @@ export const useMainAccountStorageBalance = (
   );
 };
 
-export const useChildAccounts = (
-  network: string | undefined | null,
-  mainAccountAddress: string | undefined | null
-) => {
-  return useCachedData<WalletAccount[]>(
-    network && mainAccountAddress ? childAccountsKey(network, mainAccountAddress) : null
-  );
-};
-
 export const useChildAccountAllowTypes = (
   network: string | undefined | null,
   parentAccountAddress: string | undefined | null,
@@ -78,14 +66,6 @@ export const useChildAccountAllowTypes = (
     network && parentAccountAddress && childAccountAddress
       ? childAccountAllowTypesKey(network, parentAccountAddress, childAccountAddress)
       : null
-  );
-};
-export const useEvmAccount = (
-  network: string | undefined | null,
-  mainAccountAddress: string | undefined | null
-) => {
-  return useCachedData<WalletAccount>(
-    network && mainAccountAddress ? evmAccountKey(network, mainAccountAddress) : null
   );
 };
 

--- a/src/ui/hooks/useProfileHook.ts
+++ b/src/ui/hooks/useProfileHook.ts
@@ -11,9 +11,7 @@ import { useNetwork } from '@/ui/hooks/useNetworkHook';
 
 import {
   useActiveAccounts,
-  useChildAccounts,
   useCurrentId,
-  useEvmAccount,
   useKeyringIds,
   useAccountBalance,
   useMainAccounts,
@@ -64,8 +62,6 @@ export const useProfiles = () => {
   const walletList = mainAccounts ?? [];
   // The accounts that have been selected by the user
   const activeAccounts = useActiveAccounts(network, userWallets?.currentPubkey);
-  // The child accounts for the currently active main account
-  const childAccounts = useChildAccounts(network, activeAccounts?.parentAddress);
 
   const currentBalance = useAccountBalance(network, activeAccounts?.currentAddress);
 
@@ -75,6 +71,9 @@ export const useProfiles = () => {
     walletList.find((wallet) => wallet.address === activeAccounts?.parentAddress) ??
     INITIAL_ACCOUNT;
 
+  // The child accounts for the currently active main account
+  const childAccounts = parentWallet?.childAccounts;
+
   const parentWalletIndex = walletList.findIndex(
     (wallet) => wallet.address === activeAccounts?.currentAddress
   );
@@ -82,7 +81,7 @@ export const useProfiles = () => {
   const otherAccounts = walletList.filter((wallet) => wallet.id !== parentWallet.id);
 
   // The EVM address for the currently active main account
-  const evmAccount = useEvmAccount(network, activeAccounts?.parentAddress);
+  const evmAccount = parentWallet?.evmAccount;
   const evmLoading = evmAccount === undefined;
   const evmWallet = evmAccount ?? INITIAL_WALLET;
 

--- a/src/ui/views/Dashboard/Components/MenuDrawer.tsx
+++ b/src/ui/views/Dashboard/Components/MenuDrawer.tsx
@@ -15,7 +15,7 @@ import React, { useCallback, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
 
 import type { UserInfoResponse } from '@/shared/types/network-types';
-import { type WalletAccount } from '@/shared/types/wallet-types';
+import { type MainAccount, type WalletAccount } from '@/shared/types/wallet-types';
 import { consoleError } from '@/shared/utils/console-log';
 import { AccountListing } from '@/ui/components/account/account-listing';
 import { ProfileItemBase } from '@/ui/components/profile/profile-item-base';
@@ -40,9 +40,9 @@ interface MenuDrawerProps {
   toggleDrawer: () => void;
   userInfo?: UserInfoResponse;
   togglePop: () => void;
-  walletList: WalletAccount[];
+  walletList: MainAccount[];
   activeAccount: WalletAccount;
-  activeParentAccount: WalletAccount;
+  activeParentAccount: MainAccount;
   network: string;
   modeOn: boolean;
   mainAddressLoading: boolean;

--- a/src/ui/views/Dashboard/Components/stories/MenuDrawer.stories.tsx
+++ b/src/ui/views/Dashboard/Components/stories/MenuDrawer.stories.tsx
@@ -6,11 +6,7 @@ import emojisJson from '@/background/utils/emoji.json';
 const { emojis } = emojisJson as { emojis: Emoji[] };
 import { type FeatureFlagKey } from '@/shared/types/feature-types';
 import { MAINNET_CHAIN_ID, type UserInfoResponse } from '@/shared/types/network-types';
-import { type Emoji, type WalletAccount } from '@/shared/types/wallet-types';
-import {
-  useChildAccounts as importedMockUseChildAccounts,
-  useEvmAccount as importedMockUseEvmAccount,
-} from '@/ui/hooks/use-account-hooks.mock';
+import { type MainAccount, type Emoji, type WalletAccount } from '@/shared/types/wallet-types';
 import { useFeatureFlag as importedMockUseFeatureFlag } from '@/ui/hooks/use-feature-flags.mock';
 import { useNftCatalogCollections as importedMockUseNftCatalogCollections } from '@/ui/hooks/useNftHook.mock';
 import {
@@ -21,7 +17,7 @@ import {
 import MenuDrawer from '../MenuDrawer';
 
 // Mock wallet accounts - aligned with account-listing stories
-const mockMainAccount: WalletAccount = {
+const mockMainAccount: MainAccount = {
   name: emojis[2].name,
   icon: emojis[2].emoji,
   color: emojis[2].bgcolor,
@@ -30,9 +26,16 @@ const mockMainAccount: WalletAccount = {
   id: 1,
   balance: '550.66005012',
   nfts: 12,
+  publicKey: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  keyIndex: 0,
+  weight: 1000,
+  signAlgo: 0,
+  signAlgoString: 'ECDSA',
+  hashAlgo: 0,
+  hashAlgoString: 'SHA256',
 };
 
-const mockMainAccount2: WalletAccount = {
+const mockMainAccount2: MainAccount = {
   name: emojis[3].name,
   icon: emojis[3].emoji,
   color: emojis[3].bgcolor,
@@ -41,6 +44,13 @@ const mockMainAccount2: WalletAccount = {
   id: 2,
   balance: '0.00000077',
   nfts: 4,
+  publicKey: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  keyIndex: 0,
+  weight: 1000,
+  signAlgo: 0,
+  signAlgoString: 'ECDSA',
+  hashAlgo: 0,
+  hashAlgoString: 'SHA256',
 };
 
 const mockEvmAccount: WalletAccount = {
@@ -125,14 +135,17 @@ const createMockData = (config: {
   return { evmAccounts, childAccounts, nfts };
 };
 
-const mockWalletList: WalletAccount[] = [mockMainAccount, mockMainAccount2];
+const mockWalletList: MainAccount[] = [
+  {
+    ...mockMainAccount,
+    evmAccount: mockEvmAccount,
+    childAccounts: [mockChildAccount1, mockChildAccount2],
+  },
+  { ...mockMainAccount2, evmAccount: mockEvmAccount2, childAccounts: [] },
+];
 
 // Remove the pending account from the regular wallet list
-const mockWalletListWithExtra: WalletAccount[] = [
-  mockMainAccount,
-  mockMainAccount2,
-  mockChildAccount1,
-];
+const mockWalletListWithExtra: MainAccount[] = [mockMainAccount, mockMainAccount2];
 
 const meta: Meta<typeof MenuDrawer> = {
   title: 'Views/Dashboard/MenuDrawer',
@@ -141,8 +154,7 @@ const meta: Meta<typeof MenuDrawer> = {
     withRouter,
     (Story, context) => {
       // Reset mocks
-      importedMockUseChildAccounts.mockReset();
-      importedMockUseEvmAccount.mockReset();
+
       importedMockUseNftCatalogCollections.mockReset();
       importedMockUseProfiles.mockReset();
       importedMockUseFeatureFlag.mockReset();
@@ -154,18 +166,6 @@ const meta: Meta<typeof MenuDrawer> = {
       });
 
       if (mockData) {
-        importedMockUseEvmAccount.mockImplementation((_network, address) => {
-          if (typeof address === 'string' && mockData.evmAccounts) {
-            return mockData.evmAccounts[address];
-          }
-          return undefined;
-        });
-        importedMockUseChildAccounts.mockImplementation((_network, address) => {
-          if (typeof address === 'string' && mockData.childAccounts) {
-            return mockData.childAccounts[address] || [];
-          }
-          return [];
-        });
         importedMockUseNftCatalogCollections.mockImplementation(() => {
           return [];
         });

--- a/src/ui/views/Dashboard/Components/stories/MenuDrawer.stories.tsx
+++ b/src/ui/views/Dashboard/Components/stories/MenuDrawer.stories.tsx
@@ -432,7 +432,7 @@ export const FullAccountHierarchyWithPending: Story = {
   args: {
     drawer: true,
     userInfo: mockUserInfo,
-    walletList: mockWalletListWithExtra,
+    walletList: mockWalletList,
     activeAccount: mockMainAccount,
     activeParentAccount: mockMainAccount,
     network: 'mainnet',


### PR DESCRIPTION
## Related Issue

Closes #1073


## Summary of Changes

- Use new script in load main accounts to get all accounts
- Removed seperate evm and child account keys

## Need Regression Testing

- [X] Yes
- [ ] No

## Risk Assessment

Changes the way the evm account is loaded

- [ ] Low
- [X] Medium
- [ ] High

## Additional Notes

<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)

<!-- Attach any screenshots that help explain your changes -->
