### PR TITLE
feat: use cached account data first before requesting for indexer data

### DIFF
--- a/src/core/service/openapi.ts
+++ b/src/core/service/openapi.ts
@@ -695,7 +695,8 @@ export class OpenApiService {
    * @param token - The custom token to login with
    */
   private _loginWithToken = async (userId: string, token: string) => {
-    this.clearAllStorage();
+    // we shouldn't need to clear storage here anymore
+    // this.clearAllStorage();
     await setPersistence(auth, indexedDBLocalPersistence);
     await signInWithCustomToken(auth, token);
     await storage.set(CURRENT_ID_KEY, userId);

--- a/src/core/service/openapi.ts
+++ b/src/core/service/openapi.ts
@@ -1872,44 +1872,67 @@ export class OpenApiService {
     return currencies;
   };
 
+  // Cache for in-flight requests to prevent duplicate API calls
+  private inFlightAccountRequests = new Map<string, Promise<PublicKeyAccount[]>>();
+
   getAccountsWithPublicKey = async (
     publicKey: string,
     network: string
   ): Promise<PublicKeyAccount[]> => {
-    const url =
-      network === 'testnet'
-        ? `https://staging.key-indexer.flow.com/key/${publicKey}`
-        : `https://production.key-indexer.flow.com/key/${publicKey}`;
-    const result = await fetch(url);
-    const json: {
-      publicKey: string;
-      accounts: {
-        address: string;
-        keyId: number;
-        weight: number;
-        sigAlgo: number;
-        hashAlgo: number;
-        isRevoked: boolean;
-        signing: string;
-        hashing: string;
-      }[];
-    } = await result.json();
+    // Create a key for this request
+    const requestKey = `${network}-${publicKey}`;
 
-    // Now massage the data to match the type we want
-    const accounts: PublicKeyAccount[] = json.accounts
-      .filter((account) => !account.isRevoked && account.weight >= 1000)
-      .map((account) => ({
-        address: account.address,
-        publicKey: json.publicKey,
-        keyIndex: account.keyId,
-        weight: account.weight,
-        signAlgo: account.sigAlgo,
-        signAlgoString: account.signing,
-        hashAlgo: account.hashAlgo,
-        hashAlgoString: account.hashing,
-      }));
+    // Check if there's already an in-flight request for this key
+    if (this.inFlightAccountRequests.has(requestKey)) {
+      return this.inFlightAccountRequests.get(requestKey)!;
+    }
 
-    return accounts;
+    const requestPromise = (async () => {
+      try {
+        const url =
+          network === 'testnet'
+            ? `https://staging.key-indexer.flow.com/key/${publicKey}`
+            : `https://production.key-indexer.flow.com/key/${publicKey}`;
+        const result = await fetch(url);
+        const json: {
+          publicKey: string;
+          accounts: {
+            address: string;
+            keyId: number;
+            weight: number;
+            sigAlgo: number;
+            hashAlgo: number;
+            isRevoked: boolean;
+            signing: string;
+            hashing: string;
+          }[];
+        } = await result.json();
+
+        // Now massage the data to match the type we want
+        const accounts: PublicKeyAccount[] = json.accounts
+          .filter((account) => !account.isRevoked && account.weight >= 1000)
+          .map((account) => ({
+            address: account.address,
+            publicKey: json.publicKey,
+            keyIndex: account.keyId,
+            weight: account.weight,
+            signAlgo: account.sigAlgo,
+            signAlgoString: account.signing,
+            hashAlgo: account.hashAlgo,
+            hashAlgoString: account.hashing,
+          }));
+
+        return accounts;
+      } finally {
+        // Clean up the in-flight request
+        this.inFlightAccountRequests.delete(requestKey);
+      }
+    })();
+
+    // Store the request promise
+    this.inFlightAccountRequests.set(requestKey, requestPromise);
+
+    return requestPromise;
   };
 
   async fetchCadenceTokenInfo(

--- a/src/core/service/userWallet.ts
+++ b/src/core/service/userWallet.ts
@@ -951,8 +951,22 @@ class UserWallet {
       }
     }
 
-    // Find any account with public key information
-    const accounts = await getAccountsByPublicKeyTuple(pubKeyTuple, network);
+    // Try to get accounts from the main accounts cache
+    let accounts: PublicKeyAccount[] = [];
+    // Get accounts from cache first, then fallback to indexer
+    const cachedP256 = await getValidData<MainAccount[]>(
+      mainAccountsKey(network, pubKeyTuple.P256.pubK)
+    );
+    const cachedSecp = await getValidData<MainAccount[]>(
+      mainAccountsKey(network, pubKeyTuple.SECP256K1.pubK)
+    );
+
+    accounts =
+      cachedP256 ||
+      cachedSecp ||
+      (await (() => {
+        return getAccountsByPublicKeyTuple(pubKeyTuple, network);
+      })());
 
     // If no accounts are found, then the registration process may not have been completed
     // Assume the default account key

--- a/src/core/service/userWallet.ts
+++ b/src/core/service/userWallet.ts
@@ -69,11 +69,7 @@ import {
   type UserWalletStore,
 } from '@/shared/utils/user-data-keys';
 
-import {
-  defaultAccountKey,
-  pubKeyAccountToAccountKey,
-  pubKeySignAlgoToAccountKey,
-} from '../utils/account-key';
+import { defaultAccountKey, pubKeyAccountToAccountKey } from '../utils/account-key';
 import {
   clearCachedData,
   getCachedData,
@@ -1019,26 +1015,9 @@ class UserWallet {
       }
     }
 
-    // Get the current signing algorithm from keyring
-    let currentSignAlgo: number;
-    let currentPubKey: string;
-    let accountKeyRequest: AccountKeyRequest;
-
-    try {
-      currentSignAlgo = keyringService.getCurrentSignAlgo();
-      currentPubKey =
-        currentSignAlgo === SIGN_ALGO_NUM_ECDSA_P256 ? keyTuple.P256.pubK : keyTuple.SECP256K1.pubK;
-
-      // Try to create account key request directly from keyring
-      accountKeyRequest = pubKeySignAlgoToAccountKey(currentPubKey, currentSignAlgo);
-    } catch (error) {
-      // Fallback: Get accounts from indexer using both public keys
-      const accounts = await getAccountsByPublicKeyTuple(keyTuple, network);
-      accountKeyRequest =
-        accounts.length === 0
-          ? defaultAccountKey(keyTuple)
-          : pubKeyAccountToAccountKey(accounts[0]);
-    }
+    const accounts = await getAccountsByPublicKeyTuple(keyTuple, network);
+    const accountKeyRequest =
+      accounts.length === 0 ? defaultAccountKey(keyTuple) : pubKeyAccountToAccountKey(accounts[0]);
 
     // Get the private key from the private key tuple
     const privateKey = tupleToPrivateKey(keyTuple, accountKeyRequest.sign_algo);

--- a/src/shared/utils/algo.ts
+++ b/src/shared/utils/algo.ts
@@ -82,3 +82,14 @@ export function getStringFromSignAlgo(value: number): SignAlgoString {
       return 'unknown'; // Handle unknown values
   }
 }
+
+export function getCompatibleHashAlgo(signAlgo: number): number {
+  switch (signAlgo) {
+    case SIGN_ALGO_NUM_ECDSA_P256:
+      return HASH_ALGO_NUM_SHA3_256;
+    case SIGN_ALGO_NUM_ECDSA_secp256k1:
+      return HASH_ALGO_NUM_SHA2_256;
+    default:
+      throw new Error(`Unsupported sign algorithm: ${signAlgo}`);
+  }
+}

--- a/src/shared/utils/cache-data-access.mock.ts
+++ b/src/shared/utils/cache-data-access.mock.ts
@@ -10,3 +10,5 @@ export const addCachedDataListener = fn(actual.addCachedDataListener).mockName(
 export const removeCachedDataListener = fn(actual.removeCachedDataListener).mockName(
   'removeCachedDataListener'
 );
+
+export const triggerRefresh = fn(actual.triggerRefresh).mockName('triggerRefresh');

--- a/src/ui/components/LandingPages/RepeatPhrase.tsx
+++ b/src/ui/components/LandingPages/RepeatPhrase.tsx
@@ -1,7 +1,7 @@
 import InfoIcon from '@mui/icons-material/Info';
-import { Button, Typography } from '@mui/material';
+import { Button, Skeleton, Typography } from '@mui/material';
 import { Box } from '@mui/system';
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import SlideRelative from '@/ui/components/SlideRelative';
 
@@ -125,7 +125,16 @@ const RepeatPhrase = ({ handleSwitchTab, mnemonic }) => {
                   <Typography variant="body1" sx={{ padding: '12px 0 12px' }}>
                     {chrome.i18n.getMessage('Select_the_word_at')}
                     <Typography component="span" color="primary.main" display="inline">
-                      {' #' + (chosenIndex[i] + 1) + ' '}
+                      {chosenIndex.length >= i ? (
+                        ' #' + (chosenIndex[i] + 1) + ' '
+                      ) : (
+                        <Skeleton
+                          variant="text"
+                          width={10}
+                          height={10}
+                          sx={{ display: 'inline' }}
+                        />
+                      )}
                     </Typography>
                   </Typography>
                   <Box


### PR DESCRIPTION
Closes #1100

## Related Issue

Closes #1100

<!-- If this PR addresses an issue, link it here  -->

## Summary of Changes

Checks the cached data for accounts before requesting indexer for login.
## Need Regression Testing

<!-- Indicate whether this PR requires regression testing and why. -->

- [x] Yes
- [ ] No

## Risk Assessment

<!-- Assess the risk level of this PR:
- Low: Minimal impact, straightforward changes.
- Medium: Potential for some edge cases or indirect effects.
- High: Could affect critical functionality or many users.
-->

- [ ] Low
- [x] Medium
- [ ] High

## Additional Notes

<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)

<!-- Attach any screenshots that help explain your changes -->
