### PR TITLE
Moved all frames back to false

### DIFF
--- a/apps/extension/_raw/manifest/manifest.dev.json
+++ b/apps/extension/_raw/manifest/manifest.dev.json
@@ -34,7 +34,7 @@
     {
       "js": ["content-script.js", "script.js"],
       "matches": ["file://*/*", "http://*/*", "https://*/*"],
-      "all_frames": true
+      "all_frames": false
     }
   ],
   "content_security_policy": {

--- a/apps/extension/_raw/manifest/manifest.pro.json
+++ b/apps/extension/_raw/manifest/manifest.pro.json
@@ -34,7 +34,7 @@
     {
       "js": ["content-script.js", "script.js"],
       "matches": ["file://*/*", "http://*/*", "https://*/*"],
-      "all_frames": true
+      "all_frames": false
     }
   ],
   "content_security_policy": {


### PR DESCRIPTION

## Related Issue

Closes #1149

## Summary of Changes

Changed the all_frames in the manifest back to false. Leaving that on causes the extension to authorise the connector url not the domain of the site.

## Need Regression Testing

We should test the dApp connectsion. Kittypunch leaderboard etc as that's why we introduced this in the first place

- [X] Yes
- [ ] No

## Risk Assessment


- [ ] Low
- [X] Medium
- [ ] High

## Additional Notes

<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)

<!-- Attach any screenshots that help explain your changes -->
