### PR TITLE
1208-bug-move-nft-from-child-broken

### DIFF
--- a/src/ui/views/Linked/LinkedNftDetail.tsx
+++ b/src/ui/views/Linked/LinkedNftDetail.tsx
@@ -8,7 +8,6 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
 import fallback from '@/ui/assets/image/errorImage.png';
-import DetailMove from '@/ui/assets/svg/detailMove.svg';
 import SendIcon from '@/ui/assets/svg/detailSend.svg';
 import { useWallet } from '@/ui/hooks/use-wallet';
 import { useProfiles } from '@/ui/hooks/useProfileHook';
@@ -481,7 +480,8 @@ const LinkedNftDetail = () => {
               {chrome.i18n.getMessage('Send')}
             </Button>
           )}
-
+          {/* TODO: TB July 2025. This is not working as the script doesn't exist. Turning off for now */}
+          {/*
           {nftDetail?.collectionID && (
             <Button
               sx={{
@@ -498,7 +498,6 @@ const LinkedNftDetail = () => {
               disabled={!isAccessibleNft}
               onClick={() => setMoveOpen(true)}
             >
-              {/* <IosShareOutlinedIcon color="primary" /> */}
               <CardMedia
                 image={DetailMove}
                 sx={{ width: '20px', height: '20px', color: '#fff', marginRight: '8px' }}
@@ -506,6 +505,7 @@ const LinkedNftDetail = () => {
               {chrome.i18n.getMessage('Move')}
             </Button>
           )}
+          */}
         </Box>
 
         {moveOpen && (

--- a/src/ui/views/NFT/Detail.tsx
+++ b/src/ui/views/NFT/Detail.tsx
@@ -49,17 +49,20 @@ const Detail = () => {
   const [contactOne, setContactOne] = useState<any>(emptyContact);
   const [contactTwo, setContactTwo] = useState<any>(emptyContact);
   const [isAccessibleNft, setisAccessibleNft] = useState<any>(false);
-  const [canMoveChild, setCanMoveChild] = useState(true);
 
+  // TB July 2025. This always fails as the script doesn't exist. Turning off for now
+  const [canMoveChild, setCanMoveChild] = useState(false);
+  /*
   useEffect(() => {
     const checkPermission = async () => {
+      // TODO: TB July 2025. This always fails as the script doesn't exist. Turning off for now
       const result = await usewallet.checkCanMoveChild(currentWallet.address);
       setCanMoveChild(result);
     };
 
     checkPermission();
   }, [usewallet, currentWallet.address]);
-
+ */
   useEffect(() => {
     const savedState = localStorage.getItem('nftDetailState');
     if (savedState) {

--- a/src/ui/views/Welcome/Register/index.tsx
+++ b/src/ui/views/Welcome/Register/index.tsx
@@ -1,7 +1,7 @@
 import { Box } from '@mui/material';
 import * as bip39 from 'bip39';
 import React, { useCallback, useEffect, useReducer } from 'react';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 
 import {
   INITIAL_REGISTER_STATE,
@@ -28,6 +28,8 @@ export const initRegisterState = (initialState: RegisterState): RegisterState =>
 
 const Register = () => {
   const navigate = useNavigate();
+  const location = useLocation();
+
   const usewallet = useWallet();
 
   const [state, dispatch] = useReducer(registerReducer, INITIAL_REGISTER_STATE, initRegisterState);
@@ -66,11 +68,15 @@ const Register = () => {
     }
   };
 
+  // Only show the back button if there is a page to go back to
+  const showBackButton =
+    activeTab !== STEPS.ALL_SET && (activeTab !== STEPS.USERNAME || location.key !== 'default');
+
   return (
     <LandingComponents
       activeIndex={Object.values(STEPS).indexOf(activeTab)}
       direction="right"
-      showBackButton={activeTab !== STEPS.ALL_SET}
+      showBackButton={showBackButton}
       onBack={goBack}
       showConfetti={activeTab === STEPS.ALL_SET}
       showRegisterHeader={true}


### PR DESCRIPTION


## Related Issue

Closes #1208

## Summary of Changes

Turned off move from child until we can fix it properly. Send still seems to work
Also fixed back button on create new profile

## Need Regression Testing

- [X] Yes
- [ ] No

## Risk Assessment


- [X] Low
- [ ] Medium
- [ ] High

## Additional Notes

The user can still use send to send an nft from child to parent
