### PR TITLE
1208-bug-move-nft-from-child-broken-part2

### DIFF
--- a/src/ui/components/PrivateRoute.tsx
+++ b/src/ui/components/PrivateRoute.tsx
@@ -1,13 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { Navigate } from 'react-router';
 
-import { useWallet } from '@/ui/hooks/use-wallet';
+import { useWallet, useWalletLoaded } from '@/ui/hooks/use-wallet';
 
 import { getUiType } from '../utils';
 import { openInternalPageInTab } from '../utils/webapi';
 
 const PrivateRoute = ({ children }) => {
   const wallet = useWallet();
+  const walletLoaded = useWalletLoaded();
 
   const [booted, setBooted] = useState(false);
   const [unlocked, setUnlocked] = useState(false);
@@ -28,20 +29,21 @@ const PrivateRoute = ({ children }) => {
         return { booted, unlocked };
       }
     };
-
-    // Initial check
-    fetchLockState().then(({ booted, unlocked }) => {
-      if (mounted) {
-        setBooted(booted);
-        setUnlocked(unlocked);
-        setLoading(false);
-      }
-    });
+    if (walletLoaded) {
+      // Initial check
+      fetchLockState().then(({ booted, unlocked }) => {
+        if (mounted) {
+          setBooted(booted);
+          setUnlocked(unlocked);
+          setLoading(false);
+        }
+      });
+    }
 
     return () => {
       mounted = false;
     };
-  }, [wallet]);
+  }, [wallet, walletLoaded]);
 
   if (loading) {
     // If we haven't loaded, we can't make a decision on whether to render the children

--- a/src/ui/views/NFT/Detail.tsx
+++ b/src/ui/views/NFT/Detail.tsx
@@ -51,7 +51,9 @@ const Detail = () => {
   const [isAccessibleNft, setisAccessibleNft] = useState<any>(false);
 
   // TB July 2025. This always fails as the script doesn't exist. Turning off for now
-  const [canMoveChild, setCanMoveChild] = useState(false);
+  // const [canMoveChild, setCanMoveChild] = useState(false);
+
+  const canMoveChild = activeAccountType !== 'child' && currentWallet.address;
   /*
   useEffect(() => {
     const checkPermission = async () => {

--- a/src/ui/views/SortHat.tsx
+++ b/src/ui/views/SortHat.tsx
@@ -3,12 +3,13 @@ import { Navigate } from 'react-router';
 
 import Spin from '@/ui/components/Spin';
 import { useApproval } from '@/ui/hooks/use-approval';
-import { useWallet } from '@/ui/hooks/use-wallet';
+import { useWallet, useWalletLoaded } from '@/ui/hooks/use-wallet';
 import { getUiType } from '@/ui/utils';
 import { openInternalPageInTab } from '@/ui/utils/webapi';
 
 const SortHat = () => {
   const wallet = useWallet();
+  const walletLoaded = useWalletLoaded();
   const [to, setTo] = useState('');
   // eslint-disable-next-line prefer-const
   let [getApproval, , rejectApproval] = useApproval();
@@ -68,8 +69,10 @@ const SortHat = () => {
   }, [getApproval, rejectApproval, wallet]);
 
   useEffect(() => {
-    loadView();
-  }, [loadView]);
+    if (walletLoaded) {
+      loadView();
+    }
+  }, [loadView, walletLoaded]);
 
   return (
     // <Box sx={{}}>


### PR DESCRIPTION

## Related Issue

Closes #1208

## Summary of Changes

Re-enabled move button for NFTs on main accounts
Fixed an issue that caused the welcome page to display on install even when I had an existing wallet

## Need Regression Testing

- [X] Yes
- [ ] No

## Risk Assessment


- [X] Low
- [ ] Medium
- [ ] High


